### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,3 +143,11 @@ install(DIRECTORY contents/
 add_subdirectory(package)
 
 install(DIRECTORY package/ DESTINATION ${KDE_INSTALL_DATADIR}/plasma/plasmoids/de.agundur.kcast)
+
+install(FILES package/contents/icons/kcast_icon.svg
+    DESTINATION ${KDE_INSTALL_ICONDIR}/hicolor/scalable/apps
+    RENAME de.agundur.kcast.svg)
+
+install(FILES package/contents/icons/kcast-symbolic.svg
+    DESTINATION ${KDE_INSTALL_ICONDIR}/hicolor/symbolic/apps
+    RENAME de.agundur.kcast-symbolic.svg)


### PR DESCRIPTION
Added install rules for the KCast app icons so Plasma can resolve the plasmoid’s custom icon properly in the widget menu. The main SVG now installs into the regular app icon path, and the symbolic variant installs into the symbolic icon path.