### PR TITLE
Add seek support, session tabs, and local file casting fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,3 +143,11 @@ install(DIRECTORY contents/
 add_subdirectory(package)
 
 install(DIRECTORY package/ DESTINATION ${KDE_INSTALL_DATADIR}/plasma/plasmoids/de.agundur.kcast)
+
+install(FILES package/contents/icons/kcast_icon.svg
+    DESTINATION ${KDE_INSTALL_ICONDIR}/hicolor/scalable/apps
+    RENAME de.agundur.kcast.svg)
+
+install(FILES package/contents/icons/kcast-symbolic.svg
+    DESTINATION ${KDE_INSTALL_ICONDIR}/hicolor/symbolic/apps
+    RENAME de.agundur.kcast-symbolic.svg)

--- a/package/contents/ui/FullRepresentation.qml
+++ b/package/contents/ui/FullRepresentation.qml
@@ -16,33 +16,85 @@ import org.kde.plasma.core as PlasmaCore
 import org.kde.plasma.plasmoid
 
 Item {
-    property string defaultDevice: Plasmoid.configuration.DefaultDevice
-    property bool isPaused: false
-    property int selectedIndex: -1
+    id: fullRoot
+
     property var devices: []
     property bool isScanning: false
-    property bool isPlaying: false
+    property string activeSessionDevice: ""
     property int volumeStepBig: 5
     property int volumeStepSmall: 1
+    property int seekJumpSeconds: 10
     property int currentVolume: 50
+    property int seekPreviewPosition: 0
+    property int pendingSeekPosition: -1
+    property string pendingSeekDevice: ""
+    property string pendingSessionDevice: ""
+    property string pendingVolumeDevice: ""
+    property int pendingVolumeValue: -1
+    property int seekSettleTolerance: 2
     property bool muted: false
-    property bool userInteracting: false
-    property int volumeIgnoreMs: 500
-    property double lastUserTs: 0
-    property bool deviceReady: !!(kcast && kcast.defaultDevice && kcast.defaultDevice.length > 0)
-    readonly property bool controlsEnabled: !!(kcast.defaultDevice && kcast.defaultDevice.length > 0)
+    readonly property int pageMargin: Kirigami.Units.largeSpacing
+    readonly property int sectionSpacing: Kirigami.Units.mediumSpacing
+    readonly property int controlSpacing: Kirigami.Units.smallSpacing
+    readonly property string selectedDevice: typeof deviceSelector.currentText === "string" ? deviceSelector.currentText : ""
+    readonly property string targetDevice: currentSessionDevice.length > 0 ? currentSessionDevice : selectedDevice
+    readonly property bool deviceReady: selectedDevice.length > 0
+    readonly property bool controlsEnabled: deviceReady
     readonly property bool hasMedia: typeof mediaUrl.text === "string" && mediaUrl.text.trim().length > 0
-    property bool wasPaused: false
-    property bool hasSession: false
-    readonly property bool canPlay: controlsEnabled && hasMedia && !hasSession
+    readonly property var sessionList: (kcast && kcast.sessions !== undefined && kcast.sessions !== null) ? kcast.sessions : []
+    readonly property int sessionCount: (sessionList && sessionList.length !== undefined) ? sessionList.length : 0
+    readonly property bool hasSession: sessionCount > 0
+    readonly property int activeSessionIndex: sessionIndexForDevice(activeSessionDevice)
+    readonly property var currentSession: hasSession ? (activeSessionIndex >= 0 && activeSessionIndex < sessionCount ? sessionList[activeSessionIndex] : sessionList[0]) : null
+    readonly property string currentSessionDevice: currentSession && currentSession.device ? String(currentSession.device) : ""
+    readonly property int currentSessionPosition: currentSession && currentSession.mediaPosition !== undefined ? Number(currentSession.mediaPosition) : 0
+    readonly property int currentSessionDuration: currentSession && currentSession.mediaDuration !== undefined ? Number(currentSession.mediaDuration) : 0
+    readonly property bool currentSessionPlaying: !!(currentSession && currentSession.playing)
+    readonly property bool hasSessionForSelectedDevice: !!(kcast && typeof deviceSelector.currentText === "string" && deviceSelector.currentText.length > 0 && kcast.hasSessionForDevice(deviceSelector.currentText))
+    readonly property bool seekPending: pendingSeekPosition >= 0
+    readonly property bool canSeek: !!(currentSession && currentSession.mediaSeekable && currentSessionDuration > 0)
+    readonly property bool canPlay: controlsEnabled && hasMedia
 
     function refreshDevices() {
-        console.log(i18n("refreashing"));
-        devices = kcast.scanDevicesAsync();
+        startScan();
     }
 
     function devs() {
-        return (kcast && kcast.devices) ? kcast.devices : [];
+        return (kcast && kcast.devices !== undefined && kcast.devices !== null) ? kcast.devices : [];
+    }
+
+    function deviceOptions() {
+        const sharedDevices = devs();
+        if (sharedDevices && sharedDevices.length !== undefined && sharedDevices.length > 0)
+            return sharedDevices;
+
+        if (kcast && kcast.defaultDevice && kcast.defaultDevice.length > 0)
+            return [kcast.defaultDevice];
+
+        return [];
+    }
+
+    function indexOfDevice(deviceName) {
+        const options = deviceOptions();
+        for (let i = 0; i < options.length; ++i) {
+            if (String(options[i]) === deviceName)
+                return i;
+        }
+
+        return -1;
+    }
+
+    function sessionIndexForDevice(deviceName) {
+        if (!deviceName)
+            return -1;
+
+        for (let i = 0; i < sessionCount; ++i) {
+            const session = sessionList[i];
+            if (session && String(session.device || "") === deviceName)
+                return i;
+        }
+
+        return -1;
     }
 
     function startScan() {
@@ -52,31 +104,156 @@ Item {
     }
 
     function _play() {
-        let url = mediaUrl.text || "";
-        if (url.startsWith("file://"))
-            url = url.replace(/^file:\/\//, "");
+        const targetDevice = selectedDevice || kcast.defaultDevice || currentSessionDevice || kcast.firstActiveSessionDevice() || "";
+        const normalized = updateMediaInput(mediaUrl.text || "");
+        if (!targetDevice || !normalized)
+            return;
 
-        kcast.CastFile(url);
+        pendingSessionDevice = targetDevice;
+        if (kcast.defaultDevice !== targetDevice)
+            kcast.setDefaultDevice(targetDevice);
+
+        kcast.CastFile(normalized);
+    }
+
+    function updateMediaInput(input) {
+        const normalized = kcast.normalizeMediaInput(String(input || ""));
+        if (!normalized)
+            return "";
+
+        mediaUrl.text = normalized;
+        kcast.mediaUrl = normalized;
+        return normalized;
+    }
+
+    function formatMediaTime(totalSeconds) {
+        const safeSeconds = Math.max(0, Math.floor(Number(totalSeconds) || 0));
+        const hours = Math.floor(safeSeconds / 3600);
+        const minutes = Math.floor((safeSeconds % 3600) / 60);
+        const seconds = safeSeconds % 60;
+
+        function pad(value) {
+            return value < 10 ? "0" + value : String(value);
+        }
+
+        return pad(hours) + ":" + pad(minutes) + ":" + pad(seconds);
+    }
+
+    function clearPendingSeek(resetToCurrentSession) {
+        seekSettleTimer.stop();
+        pendingSeekPosition = -1;
+        pendingSeekDevice = "";
+
+        if (resetToCurrentSession)
+            seekPreviewPosition = currentSessionPosition;
+    }
+
+    function queueVolumeChange() {
+        pendingVolumeDevice = targetDevice;
+        pendingVolumeValue = currentVolume;
+        if (pendingVolumeDevice.length > 0)
+            volumeDebounce.restart();
+    }
+
+    function sendVolumeImmediately() {
+        const device = pendingVolumeDevice.length > 0 ? pendingVolumeDevice : targetDevice;
+        const value = pendingVolumeValue >= 0 ? pendingVolumeValue : currentVolume;
+        pendingVolumeDevice = "";
+        pendingVolumeValue = -1;
+
+        if (!device || !kcast || !kcast.setVolumeForDevice)
+            return false;
+
+        return kcast.setVolumeForDevice(device, value);
+    }
+
+    function requestSeekPosition(seconds) {
+        if (!canSeek || !currentSessionDevice)
+            return false;
+
+        const maxPosition = currentSessionDuration > 0 ? currentSessionDuration : seconds;
+        const targetPosition = Math.max(0, Math.min(Math.round(seconds), maxPosition));
+
+        seekPreviewPosition = targetPosition;
+        pendingSeekPosition = targetPosition;
+        pendingSeekDevice = currentSessionDevice;
+        seekSettleTimer.restart();
+
+        if (!kcast.seekOnDevice(currentSessionDevice, targetPosition)) {
+            clearPendingSeek(false);
+            seekPreviewPosition = currentSessionPosition;
+            return false;
+        }
+
+        return true;
+    }
+
+    function jumpSeek(deltaSeconds) {
+        if (!canSeek)
+            return;
+
+        const basePosition = seekPending ? pendingSeekPosition : currentSessionPosition;
+        requestSeekPosition(basePosition + deltaSeconds);
+    }
+
+    function syncCurrentSessionUi() {
+        if (!currentSession) {
+            clearPendingSeek(false);
+            seekPreviewPosition = 0;
+            if (!volumeSlider.pressed)
+                currentVolume = 50;
+            muted = false;
+            return;
+        }
+
+        if (seekPending && pendingSeekDevice !== currentSessionDevice)
+            clearPendingSeek(false);
+
+        if (!seekSlider.pressed) {
+            if (seekPending) {
+                if (Math.abs(currentSessionPosition - pendingSeekPosition) <= seekSettleTolerance) {
+                    clearPendingSeek(false);
+                    seekPreviewPosition = currentSessionPosition;
+                } else {
+                    seekPreviewPosition = pendingSeekPosition;
+                }
+            } else if (currentSessionDuration > 0) {
+                seekPreviewPosition = Math.min(currentSessionPosition, currentSessionDuration);
+            } else {
+                seekPreviewPosition = currentSessionPosition;
+            }
+        }
+
+        if (!volumeSlider.pressed)
+            currentVolume = currentSession.volume !== undefined ? Number(currentSession.volume) : 50;
+        muted = !!currentSession.muted;
+    }
+
+    function selectSessionDevice(deviceName) {
+        if (!deviceName || sessionIndexForDevice(deviceName) < 0)
+            return;
+
+        activeSessionDevice = deviceName;
     }
 
     function _pause() {
-        kcast.pauseMedia(deviceSelector.currentText);
+        if (currentSessionDevice)
+            kcast.pauseMedia(currentSessionDevice);
     }
 
     function _resume() {
-        kcast.resumeMedia(deviceSelector.currentText);
+        if (currentSessionDevice)
+            kcast.resumeMedia(currentSessionDevice);
     }
 
     function _stop() {
-        kcast.stopMedia(deviceSelector.currentText);
-    }
-
-    function markUserAction() {
-        lastUserTs = Date.now();
+        if (currentSessionDevice)
+            kcast.stopMedia(currentSessionDevice);
     }
 
     Component.onCompleted: {
         mediaUrl.text = kcast.mediaUrl;
+        syncCurrentSessionUi();
         if (!kcast) {
             console.warn(i18n("Plugin not available!"));
             return ;
@@ -97,10 +274,32 @@ Item {
             startScan();
 
     }
-    Layout.minimumWidth: deviceList.implicitWidth + 100
-    Layout.minimumHeight: logoWrapper.implicitHeight + deviceList.implicitHeight + mediaUrl.implicitHeight + mediaControls.implicitHeight + 200
-    implicitWidth: FullRepresentation.implicitWidth > 0 ? FullRepresentation.implicitWidth : 320
-    implicitHeight: FullRepresentation.implicitHeight > 0 ? FullRepresentation.implicitHeight : 300
+    onCurrentSessionChanged: syncCurrentSessionUi()
+    onCurrentSessionDeviceChanged: syncCurrentSessionUi()
+    onSessionListChanged: {
+        if (!hasSession) {
+            activeSessionDevice = "";
+            pendingSessionDevice = "";
+            syncCurrentSessionUi();
+            return ;
+        }
+
+        if (pendingSessionDevice.length > 0) {
+            selectSessionDevice(pendingSessionDevice);
+            pendingSessionDevice = "";
+        }
+
+        if (!activeSessionDevice || sessionIndexForDevice(activeSessionDevice) < 0) {
+            const fallbackSession = sessionList[0];
+            activeSessionDevice = fallbackSession && fallbackSession.device ? String(fallbackSession.device) : "";
+        }
+
+        syncCurrentSessionUi();
+    }
+    Layout.minimumWidth: Math.max(320, contentColumn.implicitWidth + (pageMargin * 2))
+    Layout.minimumHeight: implicitHeight
+    implicitWidth: Math.max(320, contentColumn.implicitWidth + (pageMargin * 2))
+    implicitHeight: contentColumn.implicitHeight + (pageMargin * 2)
 
     Timer {
         id: volumeDebounce
@@ -108,9 +307,17 @@ Item {
         interval: 80
         repeat: false
         onTriggered: {
-            if (kcast && kcast.setVolume)
-                kcast.setVolume(currentVolume);
+            sendVolumeImmediately();
+        }
+    }
 
+    Timer {
+        id: seekSettleTimer
+
+        interval: 1200
+        repeat: false
+        onTriggered: {
+            clearPendingSeek(true);
         }
     }
 
@@ -130,7 +337,7 @@ Item {
                 url = drop.text;
             if (url !== "") {
                 console.log(i18n("URL detected: %1").arg(url));
-                mediaUrl.text = url;
+                updateMediaInput(url);
             } else {
                 console.log(i18n("Not a valid url"));
                 drop.accept(Qt.IgnoreAction);
@@ -146,11 +353,15 @@ Item {
     }
 
     ColumnLayout {
+        id: contentColumn
+
         // Platzhalter
 
-        anchors.fill: parent
-        spacing: 12
-        anchors.margins: Kirigami.Units.largeSpacing
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: parent.top
+        anchors.margins: pageMargin
+        spacing: sectionSpacing
 
         RowLayout {
             Item {
@@ -183,7 +394,7 @@ Item {
         }
 
         PlasmaComponents.Label {
-            text: devices.length > 0 ? i18n("Select device:") : i18n("No device found")
+            text: deviceOptions().length > 0 ? i18n("Select device:") : (isScanning ? i18n("Searching for devices...") : i18n("No device found"))
             Layout.fillWidth: true
             horizontalAlignment: Text.AlignHCenter
         }
@@ -191,23 +402,24 @@ Item {
         // 1) Device-Liste (ComboBox)
         RowLayout {
             id: deviceList
-
-            Component.onCompleted: {
-                if (devices.length > 0)
-                    selectedIndex = 0;
-                else
-                    selectedIndex = -1;
-            }
             Layout.fillWidth: true
 
             PlasmaComponents.ComboBox {
                 id: deviceSelector
 
                 Layout.fillWidth: true
-                model: devs().length > 0 ? devs() : (kcast.defaultDevice && kcast.defaultDevice.length > 0 ? [kcast.defaultDevice] : [])
+                model: deviceOptions()
+                Component.onCompleted: {
+                    const deviceIndex = indexOfDevice(kcast.defaultDevice);
+                    if (deviceIndex >= 0)
+                        currentIndex = deviceIndex;
+                    else if (deviceOptions().length > 0)
+                        currentIndex = 0;
+                }
                 onActivated: (i) => {
-                    if (i >= 0 && i < model.length)
-                        kcast.setDefaultDevice(model[i]);
+                    const options = deviceOptions();
+                    if (i >= 0 && i < options.length)
+                        kcast.setDefaultDevice(options[i]);
 
                 }
             }
@@ -232,7 +444,7 @@ Item {
                 // 1) UI initial mit Bridge befüllen
                 Component.onCompleted: mediaUrl.text = kcast.mediaUrl
                 // 3) Wenn der Nutzer tippt → zurück in die Bridge spiegeln
-                onTextEdited: kcast.setMediaUrl(text)
+                onTextEdited: kcast.mediaUrl = text
 
                 // 2) Wenn die Bridge (z.B. via D-Bus) mediaUrl ändert → UI nachziehen
                 Connections {
@@ -299,61 +511,134 @@ Item {
 
             Layout.fillWidth: true
             Layout.alignment: Qt.AlignHCenter
-            spacing: 8
+            spacing: controlSpacing
 
             PlasmaComponents.Button {
                 id: playBtn
 
-                text: i18n("Play")
+                text: hasSessionForSelectedDevice ? i18n("Replace Cast") : i18n("Cast")
                 icon.name: "media-playback-start"
                 enabled: canPlay
-                checkable: true
-                checked: kcast.playing
                 onClicked: {
-                    var raw = mediaUrl.text;
-                    var cleaned = raw;
-                    if (raw.startsWith("file://")) {
-                        cleaned = raw.replace(/^file:\/\//, "");
-                        mediaUrl.text = cleaned;
-                    }
-                    kcast.CastFile(cleaned);
-                    wasPaused = false;
-                    hasSession = true;
+                    _play();
                 }
             }
 
             PlasmaComponents.Button {
                 id: pauseBtn
 
-                checkable: true
-                checked: kcast.playing
-                text: checked ? i18n("Pause") : i18n("Resume")
-                icon.name: checked ? "media-playback-pause" : "media-playback-start"
-                enabled: deviceReady && hasSession
-                onToggled: (nowChecked) => {
-                    // Resume
-                    // Pause
-
-                    if (!hasSession)
-                        return ;
-
-                    if (nowChecked)
-                        kcast.resumeMedia(kcast.defaultDevice);
-                    else
-                        kcast.pauseMedia(kcast.defaultDevice);
-                }
+                text: currentSessionPlaying ? i18n("Pause") : i18n("Resume")
+                icon.name: currentSessionPlaying ? "media-playback-pause" : "media-playback-start"
+                enabled: currentSessionDevice.length > 0
+                onClicked: currentSessionPlaying ? _pause() : _resume()
             }
 
             PlasmaComponents.Button {
                 text: "Stop"
                 icon.name: "media-playback-stop"
-                enabled: controlsEnabled && hasSession
-                onClicked: {
-                    kcast.stopMedia(kcast.defaultDevice);
-                    hasSession = false; // Session beendet
+                enabled: currentSessionDevice.length > 0
+                onClicked: _stop()
+            }
+
+        }
+
+        ColumnLayout {
+            Layout.fillWidth: true
+            visible: hasSession
+            spacing: controlSpacing
+
+            PlasmaComponents.Label {
+                Layout.fillWidth: true
+                text: sessionCount === 1 ? i18n("Active session") : i18n("Active sessions")
+            }
+
+            TabBar {
+                id: sessionTabs
+
+                Layout.fillWidth: true
+                currentIndex: activeSessionIndex >= 0 ? activeSessionIndex : 0
+                onCurrentIndexChanged: {
+                    if (currentIndex < 0 || currentIndex >= sessionCount)
+                        return ;
+
+                    const session = sessionList[currentIndex];
+                    const deviceName = session && session.device ? String(session.device) : "";
+                    if (deviceName.length > 0 && activeSessionDevice !== deviceName)
+                        activeSessionDevice = deviceName;
+                }
+
+                Repeater {
+                    model: sessionList
+
+                    TabButton {
+                        text: modelData && modelData.device ? String(modelData.device) : i18n("Unknown device")
+                    }
                 }
             }
 
+            PlasmaComponents.Label {
+                Layout.fillWidth: true
+                text: currentSessionPlaying ? i18n("Playing on %1").arg(currentSessionDevice) : i18n("Paused on %1").arg(currentSessionDevice)
+                visible: currentSessionDevice.length > 0
+                elide: Text.ElideRight
+            }
+        }
+
+        RowLayout {
+            id: seekControls
+
+            Layout.fillWidth: true
+            visible: hasSession
+            spacing: controlSpacing
+
+            PlasmaComponents.Label {
+                text: formatMediaTime((seekSlider.pressed || seekPending) ? seekPreviewPosition : currentSessionPosition)
+                Layout.alignment: Qt.AlignVCenter
+            }
+
+            PlasmaComponents.Button {
+                text: i18n("-%1s").arg(seekJumpSeconds)
+                enabled: canSeek
+                onClicked: jumpSeek(-seekJumpSeconds)
+            }
+
+            PlasmaComponents.Slider {
+                id: seekSlider
+
+                Layout.fillWidth: true
+                from: 0
+                to: Math.max(1, currentSessionDuration)
+                stepSize: 1
+                live: true
+                enabled: canSeek
+                value: seekPreviewPosition
+                onValueChanged: {
+                    if (pressed)
+                        seekPreviewPosition = Math.round(value);
+                }
+                onPressedChanged: {
+                    if (pressed) {
+                        seekPreviewPosition = Math.round(value);
+                        return ;
+                    }
+
+                    if (!canSeek)
+                        return ;
+
+                    requestSeekPosition(value);
+                }
+            }
+
+            PlasmaComponents.Button {
+                text: i18n("+%1s").arg(seekJumpSeconds)
+                enabled: canSeek
+                onClicked: jumpSeek(seekJumpSeconds)
+            }
+
+            PlasmaComponents.Label {
+                text: currentSessionDuration > 0 ? formatMediaTime(currentSessionDuration) : "--:--:--"
+                Layout.alignment: Qt.AlignVCenter
+            }
         }
 
         RowLayout {
@@ -361,30 +646,31 @@ Item {
 
             Layout.fillWidth: true
             Layout.alignment: Qt.AlignHCenter
-            spacing: 8
+            spacing: controlSpacing
 
             PlasmaComponents.Button {
                 id: muteBtn
 
-                enabled: controlsEnabled
+                enabled: targetDevice.length > 0
                 checkable: true
                 checked: muted
                 icon.name: muted ? "audio-volume-muted" : "audio-volume-high"
                 // text: muted ? i18n("Unmute") : i18n("Mute")
                 Accessible.name: checked ? "Unmute" : "Mute"
                 onClicked: {
-                    kcast.setMuted(muteBtn.checked);
+                    muted = muteBtn.checked;
+                    if (targetDevice.length > 0)
+                        kcast.setMutedForDevice(targetDevice, muteBtn.checked);
                 }
             }
 
             PlasmaComponents.Button {
                 // icon.name: "media-volume-down"
                 text: i18n("-")
-                enabled: deviceReady
+                enabled: targetDevice.length > 0
                 onClicked: {
                     currentVolume = Math.max(0, currentVolume - volumeStepBig);
-                    markUserAction();
-                    volumeDebounce.restart();
+                    queueVolumeChange();
                 }
             }
 
@@ -397,7 +683,7 @@ Item {
                 stepSize: volumeStepSmall
                 live: true
                 value: currentVolume
-                enabled: deviceReady
+                enabled: targetDevice.length > 0
                 // Beim Ziehen: nur throttled (Debounce) senden
                 onValueChanged: {
                     if (!pressed)
@@ -405,7 +691,7 @@ Item {
 
                     // nur wenn der User wirklich schiebt
                     currentVolume = Math.round(value);
-                    volumeDebounce.restart();
+                    queueVolumeChange();
                 }
                 // „Loslassen“-Moment: final commit (ersetzt onReleased)
                 onPressedChanged: {
@@ -413,21 +699,23 @@ Item {
                         return ;
 
                     // wird false => Finger/Maus losgelassen
-                    if (!kcast || !kcast.setVolume)
+                    if (!kcast || !kcast.setVolumeForDevice)
                         return ;
 
                     currentVolume = Math.round(value);
-                    kcast.setVolume(currentVolume);
+                    pendingVolumeDevice = targetDevice;
+                    pendingVolumeValue = currentVolume;
+                    sendVolumeImmediately();
                 }
                 Keys.onPressed: (ev) => {
                     if (ev.key === Qt.Key_Left) {
                         currentVolume = Math.max(0, currentVolume - volumeStepSmall);
-                        volumeDebounce.restart();
+                        queueVolumeChange();
                         ev.accepted = true;
                     }
                     if (ev.key === Qt.Key_Right) {
                         currentVolume = Math.min(100, currentVolume + volumeStepSmall);
-                        volumeDebounce.restart();
+                        queueVolumeChange();
                         ev.accepted = true;
                     }
                 }
@@ -437,8 +725,7 @@ Item {
                     onWheel: (ev) => {
                         const d = ev.angleDelta.y > 0 ? volumeStepSmall : -volumeStepSmall;
                         currentVolume = Math.max(0, Math.min(100, currentVolume + d));
-                        markUserAction();
-                        volumeDebounce.restart();
+                        queueVolumeChange();
                         ev.accepted = true;
                     }
                 }
@@ -456,11 +743,10 @@ Item {
             PlasmaComponents.Button {
                 // icon.name: "media-volume-up"
                 text: i18n("+")
-                enabled: deviceReady
+                enabled: targetDevice.length > 0
                 onClicked: {
                     currentVolume = Math.min(100, currentVolume + volumeStepBig); // sofort im UI
-                    markUserAction();
-                    volumeDebounce.restart(); // nach kurzer Zeit >= setVolume()
+                    queueVolumeChange(); // nach kurzer Zeit >= setVolume()
                 }
             }
 
@@ -472,37 +758,30 @@ Item {
             title: i18n("Open file")
             nameFilters: ["Media (*.mp4 *.mkv *.webm *.mp3)", "Alle Dateien (*)"]
             onAccepted: {
-                mediaUrl.text = file;
+                updateMediaInput(file);
             }
-        }
-
-        Item {
-            Layout.fillHeight: true
-        }
-
-        Connections {
-            function onVolumeCommandSent(command, value) {
-                if (command === "set")
-                    currentVolume = value;
-
-                if (command === "up")
-                    currentVolume = Math.max(0, Math.min(100, currentVolume + value));
-
-                if (command === "down")
-                    currentVolume = Math.max(0, Math.min(100, currentVolume - value));
-
-            }
-
-            function onMuteCommandSent(on) {
-                muted = on;
-            }
-
-            target: kcast
         }
 
         Connections {
             // erstes gefundenes nehmen
             // z.B. eine Fehlermeldung sichtbar schalten
+
+            function onDefaultDeviceChanged(name) {
+                const deviceIndex = indexOfDevice(name);
+                if (deviceIndex >= 0 && deviceSelector.currentIndex !== deviceIndex)
+                    deviceSelector.currentIndex = deviceIndex;
+            }
+
+            function onDevicesChanged() {
+                if (deviceSelector.currentIndex >= 0)
+                    return ;
+
+                const deviceIndex = indexOfDevice(kcast.defaultDevice);
+                if (deviceIndex >= 0)
+                    deviceSelector.currentIndex = deviceIndex;
+                else if (deviceOptions().length > 0)
+                    deviceSelector.currentIndex = 0;
+            }
 
             function onDeviceFound(name) {
                 if (devices.indexOf(name) === -1)
@@ -515,7 +794,7 @@ Item {
             }
 
             function onDevicesScanned(list) {
-                devices = Array.isArray(list) ? list : [];
+                devices = list ? list : [];
                 isScanning = false;
                 // Optional: InlineMessage zeigen, falls leer
                 if (devices.length === 0) {

--- a/package/contents/ui/FullRepresentation.qml
+++ b/package/contents/ui/FullRepresentation.qml
@@ -33,6 +33,12 @@ Item {
     property int pendingVolumeValue: -1
     property int seekSettleTolerance: 2
     property bool muted: false
+    readonly property bool compactLayout: width > 0 && width < 360
+    readonly property bool iconOnlyButtons: width > 0 && width < 330
+    readonly property int effectivePageMargin: compactLayout ? Kirigami.Units.smallSpacing : pageMargin
+    readonly property int effectiveSectionSpacing: compactLayout ? Kirigami.Units.smallSpacing : sectionSpacing
+    readonly property int effectiveControlSpacing: compactLayout ? 4 : controlSpacing
+    readonly property int headerIconSize: compactLayout ? 40 : 64
     readonly property int pageMargin: Kirigami.Units.largeSpacing
     readonly property int sectionSpacing: Kirigami.Units.mediumSpacing
     readonly property int controlSpacing: Kirigami.Units.smallSpacing
@@ -296,10 +302,10 @@ Item {
 
         syncCurrentSessionUi();
     }
-    Layout.minimumWidth: Math.max(320, contentColumn.implicitWidth + (pageMargin * 2))
-    Layout.minimumHeight: implicitHeight
-    implicitWidth: Math.max(320, contentColumn.implicitWidth + (pageMargin * 2))
-    implicitHeight: contentColumn.implicitHeight + (pageMargin * 2)
+    Layout.minimumWidth: 250
+    Layout.minimumHeight: 220
+    implicitWidth: Math.max(280, contentColumn.implicitWidth + (effectivePageMargin * 2))
+    implicitHeight: Math.max(220, contentColumn.implicitHeight + (effectivePageMargin * 2))
 
     Timer {
         id: volumeDebounce
@@ -352,456 +358,478 @@ Item {
         }
     }
 
-    ColumnLayout {
-        id: contentColumn
+    Flickable {
+        id: contentFlick
 
-        // Platzhalter
+        anchors.fill: parent
+        boundsBehavior: Flickable.StopAtBounds
+        clip: true
+        contentWidth: width
+        contentHeight: contentColumn.implicitHeight + (effectivePageMargin * 2)
+        interactive: contentHeight > height
 
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.top: parent.top
-        anchors.margins: pageMargin
-        spacing: sectionSpacing
-
-        RowLayout {
-            Item {
-                id: logoWrapper
-
-                width: 64
-                height: 64
-                // ToolTip.visible: kcastIcon.containsMouse
-                ToolTip.delay: 500
-                ToolTip.text: "KCast"
-
-                Image {
-                    id: kcastIcon
-
-                    anchors.centerIn: parent
-                    source: Qt.resolvedUrl("../icons/kcast_icon_64x64.png")
-                    width: 64
-                    height: 64
-                    fillMode: Image.PreserveAspectFit
-                }
-
-            }
-
-            Kirigami.Heading {
-                text: i18n("KCast")
-                level: 2
-                Layout.fillWidth: true
-            }
-
-        }
-
-        PlasmaComponents.Label {
-            text: deviceOptions().length > 0 ? i18n("Select device:") : (isScanning ? i18n("Searching for devices...") : i18n("No device found"))
-            Layout.fillWidth: true
-            horizontalAlignment: Text.AlignHCenter
-        }
-
-        // 1) Device-Liste (ComboBox)
-        RowLayout {
-            id: deviceList
-            Layout.fillWidth: true
-
-            PlasmaComponents.ComboBox {
-                id: deviceSelector
-
-                Layout.fillWidth: true
-                model: deviceOptions()
-                Component.onCompleted: {
-                    const deviceIndex = indexOfDevice(kcast.defaultDevice);
-                    if (deviceIndex >= 0)
-                        currentIndex = deviceIndex;
-                    else if (deviceOptions().length > 0)
-                        currentIndex = 0;
-                }
-                onActivated: (i) => {
-                    const options = deviceOptions();
-                    if (i >= 0 && i < options.length)
-                        kcast.setDefaultDevice(options[i]);
-
-                }
-            }
-
-            PlasmaComponents.Button {
-                text: i18n("search devices")
-                icon.name: "view-refresh"
-                Layout.alignment: Qt.AlignRight
-                onClicked: {
-                    refreshDevices();
-                }
-            }
-
-        }
-
-        RowLayout {
-            TextField {
-                id: mediaUrl
-
-                Layout.fillWidth: true
-                placeholderText: i18n("http://... or /path/to/file.mp4")
-                // 1) UI initial mit Bridge befüllen
-                Component.onCompleted: mediaUrl.text = kcast.mediaUrl
-                // 3) Wenn der Nutzer tippt → zurück in die Bridge spiegeln
-                onTextEdited: kcast.mediaUrl = text
-
-                // 2) Wenn die Bridge (z.B. via D-Bus) mediaUrl ändert → UI nachziehen
-                Connections {
-                    function onMediaUrlChanged() {
-                        mediaUrl.text = kcast.mediaUrl;
-                    }
-
-                    target: kcast
-                }
-
-                MouseArea {
-                    anchors.fill: parent
-                    acceptedButtons: Qt.RightButton
-                    onPressed: {
-                        if (mouse.button === Qt.RightButton)
-                            menu.popup();
-
-                    }
-
-                    Menu {
-                        id: menu
-
-                        MenuItem {
-                            text: i18n("copy")
-                            enabled: mediaUrl.selectedText.length > 0
-                            onTriggered: mediaUrl.copy()
-                        }
-
-                        MenuItem {
-                            text: i18n("paste")
-                            onTriggered: mediaUrl.paste()
-                        }
-
-                        MenuItem {
-                            text: i18n("cut")
-                            enabled: mediaUrl.selectedText.length > 0
-                            onTriggered: mediaUrl.cut()
-                        }
-
-                        MenuItem {
-                            text: i18n("select all")
-                            onTriggered: mediaUrl.selectAll()
-                        }
-
-                    }
-
-                }
-
-            }
-
-            PlasmaComponents.Button {
-                text: i18n("open")
-                icon.name: "folder-video"
-                Layout.alignment: Qt.AlignRight
-                onClicked: {
-                    fileDialog.open();
-                }
-            }
-
-        }
-
-        RowLayout {
-            id: mediaControls
-
-            Layout.fillWidth: true
-            Layout.alignment: Qt.AlignHCenter
-            spacing: controlSpacing
-
-            PlasmaComponents.Button {
-                id: playBtn
-
-                text: hasSessionForSelectedDevice ? i18n("Replace Cast") : i18n("Cast")
-                icon.name: "media-playback-start"
-                enabled: canPlay
-                onClicked: {
-                    _play();
-                }
-            }
-
-            PlasmaComponents.Button {
-                id: pauseBtn
-
-                text: currentSessionPlaying ? i18n("Pause") : i18n("Resume")
-                icon.name: currentSessionPlaying ? "media-playback-pause" : "media-playback-start"
-                enabled: currentSessionDevice.length > 0
-                onClicked: currentSessionPlaying ? _pause() : _resume()
-            }
-
-            PlasmaComponents.Button {
-                text: "Stop"
-                icon.name: "media-playback-stop"
-                enabled: currentSessionDevice.length > 0
-                onClicked: _stop()
-            }
-
+        ScrollBar.vertical: ScrollBar {
+            policy: contentFlick.contentHeight > contentFlick.height ? ScrollBar.AsNeeded : ScrollBar.AlwaysOff
         }
 
         ColumnLayout {
-            Layout.fillWidth: true
-            visible: hasSession
-            spacing: controlSpacing
+            id: contentColumn
 
-            PlasmaComponents.Label {
-                Layout.fillWidth: true
-                text: sessionCount === 1 ? i18n("Active session") : i18n("Active sessions")
-            }
+            x: effectivePageMargin
+            y: effectivePageMargin
+            width: Math.max(0, contentFlick.width - (effectivePageMargin * 2))
+            spacing: effectiveSectionSpacing
 
-            TabBar {
-                id: sessionTabs
+            RowLayout {
+                Item {
+                    id: logoWrapper
 
-                Layout.fillWidth: true
-                currentIndex: activeSessionIndex >= 0 ? activeSessionIndex : 0
-                onCurrentIndexChanged: {
-                    if (currentIndex < 0 || currentIndex >= sessionCount)
-                        return ;
+                    width: headerIconSize
+                    height: headerIconSize
+                    // ToolTip.visible: kcastIcon.containsMouse
+                    ToolTip.delay: 500
+                    ToolTip.text: "KCast"
 
-                    const session = sessionList[currentIndex];
-                    const deviceName = session && session.device ? String(session.device) : "";
-                    if (deviceName.length > 0 && activeSessionDevice !== deviceName)
-                        activeSessionDevice = deviceName;
-                }
+                    Image {
+                        id: kcastIcon
 
-                Repeater {
-                    model: sessionList
-
-                    TabButton {
-                        text: modelData && modelData.device ? String(modelData.device) : i18n("Unknown device")
-                    }
-                }
-            }
-
-            PlasmaComponents.Label {
-                Layout.fillWidth: true
-                text: currentSessionPlaying ? i18n("Playing on %1").arg(currentSessionDevice) : i18n("Paused on %1").arg(currentSessionDevice)
-                visible: currentSessionDevice.length > 0
-                elide: Text.ElideRight
-            }
-        }
-
-        RowLayout {
-            id: seekControls
-
-            Layout.fillWidth: true
-            visible: hasSession
-            spacing: controlSpacing
-
-            PlasmaComponents.Label {
-                text: formatMediaTime((seekSlider.pressed || seekPending) ? seekPreviewPosition : currentSessionPosition)
-                Layout.alignment: Qt.AlignVCenter
-            }
-
-            PlasmaComponents.Button {
-                text: i18n("-%1s").arg(seekJumpSeconds)
-                enabled: canSeek
-                onClicked: jumpSeek(-seekJumpSeconds)
-            }
-
-            PlasmaComponents.Slider {
-                id: seekSlider
-
-                Layout.fillWidth: true
-                from: 0
-                to: Math.max(1, currentSessionDuration)
-                stepSize: 1
-                live: true
-                enabled: canSeek
-                value: seekPreviewPosition
-                onValueChanged: {
-                    if (pressed)
-                        seekPreviewPosition = Math.round(value);
-                }
-                onPressedChanged: {
-                    if (pressed) {
-                        seekPreviewPosition = Math.round(value);
-                        return ;
+                        anchors.centerIn: parent
+                        source: Qt.resolvedUrl("../icons/kcast_icon_64x64.png")
+                        width: headerIconSize
+                        height: headerIconSize
+                        fillMode: Image.PreserveAspectFit
                     }
 
-                    if (!canSeek)
-                        return ;
-
-                    requestSeekPosition(value);
                 }
-            }
 
-            PlasmaComponents.Button {
-                text: i18n("+%1s").arg(seekJumpSeconds)
-                enabled: canSeek
-                onClicked: jumpSeek(seekJumpSeconds)
+                Kirigami.Heading {
+                    text: i18n("KCast")
+                    level: compactLayout ? 3 : 2
+                    Layout.fillWidth: true
+                }
+
             }
 
             PlasmaComponents.Label {
-                text: currentSessionDuration > 0 ? formatMediaTime(currentSessionDuration) : "--:--:--"
-                Layout.alignment: Qt.AlignVCenter
+                text: deviceOptions().length > 0 ? i18n("Select device:") : (isScanning ? i18n("Searching for devices...") : i18n("No device found"))
+                Layout.fillWidth: true
+                horizontalAlignment: Text.AlignHCenter
             }
-        }
 
-        RowLayout {
-            id: volumeControls
+            // 1) Device-Liste (ComboBox)
+            RowLayout {
+                id: deviceList
+                Layout.fillWidth: true
+                spacing: effectiveControlSpacing
 
-            Layout.fillWidth: true
-            Layout.alignment: Qt.AlignHCenter
-            spacing: controlSpacing
+                PlasmaComponents.ComboBox {
+                    id: deviceSelector
 
-            PlasmaComponents.Button {
-                id: muteBtn
+                    Layout.fillWidth: true
+                    model: deviceOptions()
+                    Component.onCompleted: {
+                        const deviceIndex = indexOfDevice(kcast.defaultDevice);
+                        if (deviceIndex >= 0)
+                            currentIndex = deviceIndex;
+                        else if (deviceOptions().length > 0)
+                            currentIndex = 0;
+                    }
+                    onActivated: (i) => {
+                        const options = deviceOptions();
+                        if (i >= 0 && i < options.length)
+                            kcast.setDefaultDevice(options[i]);
 
-                enabled: targetDevice.length > 0
-                checkable: true
-                checked: muted
-                icon.name: muted ? "audio-volume-muted" : "audio-volume-high"
-                // text: muted ? i18n("Unmute") : i18n("Mute")
-                Accessible.name: checked ? "Unmute" : "Mute"
-                onClicked: {
-                    muted = muteBtn.checked;
-                    if (targetDevice.length > 0)
-                        kcast.setMutedForDevice(targetDevice, muteBtn.checked);
+                    }
                 }
-            }
 
-            PlasmaComponents.Button {
-                // icon.name: "media-volume-down"
-                text: i18n("-")
-                enabled: targetDevice.length > 0
-                onClicked: {
-                    currentVolume = Math.max(0, currentVolume - volumeStepBig);
-                    queueVolumeChange();
+                PlasmaComponents.Button {
+                    text: iconOnlyButtons ? "" : i18n("search devices")
+                    icon.name: "view-refresh"
+                    Layout.alignment: Qt.AlignRight
+                    ToolTip.visible: hovered && iconOnlyButtons
+                    ToolTip.text: i18n("search devices")
+                    onClicked: {
+                        refreshDevices();
+                    }
                 }
+
             }
 
-            PlasmaComponents.Slider {
-                id: volumeSlider
+            RowLayout {
+                spacing: effectiveControlSpacing
+
+                TextField {
+                    id: mediaUrl
+
+                    Layout.fillWidth: true
+                    placeholderText: i18n("http://... or /path/to/file.mp4")
+                    // 1) UI initial mit Bridge befüllen
+                    Component.onCompleted: mediaUrl.text = kcast.mediaUrl
+                    // 3) Wenn der Nutzer tippt → zurück in die Bridge spiegeln
+                    onTextEdited: kcast.mediaUrl = text
+
+                    // 2) Wenn die Bridge (z.B. via D-Bus) mediaUrl ändert → UI nachziehen
+                    Connections {
+                        function onMediaUrlChanged() {
+                            mediaUrl.text = kcast.mediaUrl;
+                        }
+
+                        target: kcast
+                    }
+
+                    MouseArea {
+                        anchors.fill: parent
+                        acceptedButtons: Qt.RightButton
+                        onPressed: {
+                            if (mouse.button === Qt.RightButton)
+                                menu.popup();
+
+                        }
+
+                        Menu {
+                            id: menu
+
+                            MenuItem {
+                                text: i18n("copy")
+                                enabled: mediaUrl.selectedText.length > 0
+                                onTriggered: mediaUrl.copy()
+                            }
+
+                            MenuItem {
+                                text: i18n("paste")
+                                onTriggered: mediaUrl.paste()
+                            }
+
+                            MenuItem {
+                                text: i18n("cut")
+                                enabled: mediaUrl.selectedText.length > 0
+                                onTriggered: mediaUrl.cut()
+                            }
+
+                            MenuItem {
+                                text: i18n("select all")
+                                onTriggered: mediaUrl.selectAll()
+                            }
+
+                        }
+
+                    }
+
+                }
+
+                PlasmaComponents.Button {
+                    text: iconOnlyButtons ? "" : i18n("open")
+                    icon.name: "folder-video"
+                    Layout.alignment: Qt.AlignRight
+                    ToolTip.visible: hovered && iconOnlyButtons
+                    ToolTip.text: i18n("open")
+                    onClicked: {
+                        fileDialog.open();
+                    }
+                }
+
+            }
+
+            RowLayout {
+                id: mediaControls
 
                 Layout.fillWidth: true
-                from: 0
-                to: 100
-                stepSize: volumeStepSmall
-                live: true
-                value: currentVolume
-                enabled: targetDevice.length > 0
-                // Beim Ziehen: nur throttled (Debounce) senden
-                onValueChanged: {
-                    if (!pressed)
-                        return ;
+                Layout.alignment: Qt.AlignHCenter
+                spacing: effectiveControlSpacing
 
-                    // nur wenn der User wirklich schiebt
-                    currentVolume = Math.round(value);
-                    queueVolumeChange();
+                PlasmaComponents.Button {
+                    id: playBtn
+
+                    text: hasSessionForSelectedDevice ? i18n("Replace Cast") : i18n("Cast")
+                    icon.name: "media-playback-start"
+                    enabled: canPlay
+                    onClicked: {
+                        _play();
+                    }
                 }
-                // „Loslassen“-Moment: final commit (ersetzt onReleased)
-                onPressedChanged: {
-                    if (pressed)
-                        return ;
 
-                    // wird false => Finger/Maus losgelassen
-                    if (!kcast || !kcast.setVolumeForDevice)
-                        return ;
+                PlasmaComponents.Button {
+                    id: pauseBtn
 
-                    currentVolume = Math.round(value);
-                    pendingVolumeDevice = targetDevice;
-                    pendingVolumeValue = currentVolume;
-                    sendVolumeImmediately();
+                    text: currentSessionPlaying ? i18n("Pause") : i18n("Resume")
+                    icon.name: currentSessionPlaying ? "media-playback-pause" : "media-playback-start"
+                    enabled: currentSessionDevice.length > 0
+                    onClicked: currentSessionPlaying ? _pause() : _resume()
                 }
-                Keys.onPressed: (ev) => {
-                    if (ev.key === Qt.Key_Left) {
-                        currentVolume = Math.max(0, currentVolume - volumeStepSmall);
+
+                PlasmaComponents.Button {
+                    text: "Stop"
+                    icon.name: "media-playback-stop"
+                    enabled: currentSessionDevice.length > 0
+                    onClicked: _stop()
+                }
+
+            }
+
+            ColumnLayout {
+                Layout.fillWidth: true
+                visible: hasSession
+                spacing: effectiveControlSpacing
+
+                PlasmaComponents.Label {
+                    Layout.fillWidth: true
+                    text: i18n("Active sessions")
+                    visible: sessionCount > 1
+                }
+
+                TabBar {
+                    id: sessionTabs
+
+                    Layout.fillWidth: true
+                    visible: sessionCount > 1
+                    currentIndex: activeSessionIndex >= 0 ? activeSessionIndex : 0
+                    onCurrentIndexChanged: {
+                        if (currentIndex < 0 || currentIndex >= sessionCount)
+                            return ;
+
+                        const session = sessionList[currentIndex];
+                        const deviceName = session && session.device ? String(session.device) : "";
+                        if (deviceName.length > 0 && activeSessionDevice !== deviceName)
+                            activeSessionDevice = deviceName;
+                    }
+
+                    Repeater {
+                        model: sessionList
+
+                        TabButton {
+                            text: modelData && modelData.device ? String(modelData.device) : i18n("Unknown device")
+                        }
+                    }
+                }
+
+                PlasmaComponents.Label {
+                    Layout.fillWidth: true
+                    text: currentSessionPlaying ? i18n("Playing on %1").arg(currentSessionDevice) : i18n("Paused on %1").arg(currentSessionDevice)
+                    visible: currentSessionDevice.length > 0
+                    elide: Text.ElideRight
+                }
+            }
+
+            RowLayout {
+                id: seekControls
+
+                Layout.fillWidth: true
+                visible: hasSession
+                spacing: effectiveControlSpacing
+
+                PlasmaComponents.Label {
+                    text: formatMediaTime((seekSlider.pressed || seekPending) ? seekPreviewPosition : currentSessionPosition)
+                    Layout.alignment: Qt.AlignVCenter
+                }
+
+                PlasmaComponents.Button {
+                    text: i18n("-%1s").arg(seekJumpSeconds)
+                    enabled: canSeek
+                    onClicked: jumpSeek(-seekJumpSeconds)
+                }
+
+                PlasmaComponents.Slider {
+                    id: seekSlider
+
+                    Layout.fillWidth: true
+                    from: 0
+                    to: Math.max(1, currentSessionDuration)
+                    stepSize: 1
+                    live: true
+                    enabled: canSeek
+                    value: seekPreviewPosition
+                    onValueChanged: {
+                        if (pressed)
+                            seekPreviewPosition = Math.round(value);
+                    }
+                    onPressedChanged: {
+                        if (pressed) {
+                            seekPreviewPosition = Math.round(value);
+                            return ;
+                        }
+
+                        if (!canSeek)
+                            return ;
+
+                        requestSeekPosition(value);
+                    }
+                }
+
+                PlasmaComponents.Button {
+                    text: i18n("+%1s").arg(seekJumpSeconds)
+                    enabled: canSeek
+                    onClicked: jumpSeek(seekJumpSeconds)
+                }
+
+                PlasmaComponents.Label {
+                    text: currentSessionDuration > 0 ? formatMediaTime(currentSessionDuration) : "--:--:--"
+                    Layout.alignment: Qt.AlignVCenter
+                }
+            }
+
+            RowLayout {
+                id: volumeControls
+
+                Layout.fillWidth: true
+                Layout.alignment: Qt.AlignHCenter
+                spacing: effectiveControlSpacing
+
+                PlasmaComponents.Button {
+                    id: muteBtn
+
+                    enabled: targetDevice.length > 0
+                    checkable: true
+                    checked: muted
+                    icon.name: muted ? "audio-volume-muted" : "audio-volume-high"
+                    // text: muted ? i18n("Unmute") : i18n("Mute")
+                    Accessible.name: checked ? "Unmute" : "Mute"
+                    onClicked: {
+                        muted = muteBtn.checked;
+                        if (targetDevice.length > 0)
+                            kcast.setMutedForDevice(targetDevice, muteBtn.checked);
+                    }
+                }
+
+                PlasmaComponents.Button {
+                    // icon.name: "media-volume-down"
+                    text: i18n("-")
+                    enabled: targetDevice.length > 0
+                    onClicked: {
+                        currentVolume = Math.max(0, currentVolume - volumeStepBig);
                         queueVolumeChange();
-                        ev.accepted = true;
                     }
-                    if (ev.key === Qt.Key_Right) {
-                        currentVolume = Math.min(100, currentVolume + volumeStepSmall);
+                }
+
+                PlasmaComponents.Slider {
+                    id: volumeSlider
+
+                    Layout.fillWidth: true
+                    from: 0
+                    to: 100
+                    stepSize: volumeStepSmall
+                    live: true
+                    value: currentVolume
+                    enabled: targetDevice.length > 0
+                    // Beim Ziehen: nur throttled (Debounce) senden
+                    onValueChanged: {
+                        if (!pressed)
+                            return ;
+
+                        // nur wenn der User wirklich schiebt
+                        currentVolume = Math.round(value);
                         queueVolumeChange();
-                        ev.accepted = true;
+                    }
+                    // „Loslassen“-Moment: final commit (ersetzt onReleased)
+                    onPressedChanged: {
+                        if (pressed)
+                            return ;
+
+                        // wird false => Finger/Maus losgelassen
+                        if (!kcast || !kcast.setVolumeForDevice)
+                            return ;
+
+                        currentVolume = Math.round(value);
+                        pendingVolumeDevice = targetDevice;
+                        pendingVolumeValue = currentVolume;
+                        sendVolumeImmediately();
+                    }
+                    Keys.onPressed: (ev) => {
+                        if (ev.key === Qt.Key_Left) {
+                            currentVolume = Math.max(0, currentVolume - volumeStepSmall);
+                            queueVolumeChange();
+                            ev.accepted = true;
+                        }
+                        if (ev.key === Qt.Key_Right) {
+                            currentVolume = Math.min(100, currentVolume + volumeStepSmall);
+                            queueVolumeChange();
+                            ev.accepted = true;
+                        }
+                    }
+
+                    WheelHandler {
+                        acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad
+                        onWheel: (ev) => {
+                            const d = ev.angleDelta.y > 0 ? volumeStepSmall : -volumeStepSmall;
+                            currentVolume = Math.max(0, Math.min(100, currentVolume + d));
+                            queueVolumeChange();
+                            ev.accepted = true;
+                        }
+                    }
+
+                }
+
+                PlasmaComponents.Label {
+                    // minimumWidth: implicitWidth
+
+                    text: currentVolume + "%"
+                    Accessible.name: i18n("Volume in %")
+                    Layout.alignment: Qt.AlignVCenter
+                }
+
+                PlasmaComponents.Button {
+                    // icon.name: "media-volume-up"
+                    text: i18n("+")
+                    enabled: targetDevice.length > 0
+                    onClicked: {
+                        currentVolume = Math.min(100, currentVolume + volumeStepBig); // sofort im UI
+                        queueVolumeChange(); // nach kurzer Zeit >= setVolume()
                     }
                 }
 
-                WheelHandler {
-                    acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad
-                    onWheel: (ev) => {
-                        const d = ev.angleDelta.y > 0 ? volumeStepSmall : -volumeStepSmall;
-                        currentVolume = Math.max(0, Math.min(100, currentVolume + d));
-                        queueVolumeChange();
-                        ev.accepted = true;
+            }
+
+            Platform.FileDialog {
+                id: fileDialog
+
+                title: i18n("Open file")
+                nameFilters: ["Media (*.mp4 *.mkv *.webm *.mp3)", "Alle Dateien (*)"]
+                onAccepted: {
+                    updateMediaInput(file);
+                }
+            }
+
+            Connections {
+                // erstes gefundenes nehmen
+                // z.B. eine Fehlermeldung sichtbar schalten
+
+                function onDefaultDeviceChanged(name) {
+                    const deviceIndex = indexOfDevice(name);
+                    if (deviceIndex >= 0 && deviceSelector.currentIndex !== deviceIndex)
+                        deviceSelector.currentIndex = deviceIndex;
+                }
+
+                function onDevicesChanged() {
+                    if (deviceSelector.currentIndex >= 0)
+                        return ;
+
+                    const deviceIndex = indexOfDevice(kcast.defaultDevice);
+                    if (deviceIndex >= 0)
+                        deviceSelector.currentIndex = deviceIndex;
+                    else if (deviceOptions().length > 0)
+                        deviceSelector.currentIndex = 0;
+                }
+
+                function onDeviceFound(name) {
+                    if (devices.indexOf(name) === -1)
+                        devices = devices.concat([name]);
+
+                    // trigger Bindings
+                    if (!kcast.defaultDevice || kcast.defaultDevice.length === 0)
+                        kcast.setDefaultDevice(name);
+
+                }
+
+                function onDevicesScanned(list) {
+                    devices = list ? list : [];
+                    isScanning = false;
+                    // Optional: InlineMessage zeigen, falls leer
+                    if (devices.length === 0) {
                     }
                 }
 
+                target: kcast
             }
 
-            PlasmaComponents.Label {
-                // minimumWidth: implicitWidth
-
-                text: currentVolume + "%"
-                Accessible.name: i18n("Volume in %")
-                Layout.alignment: Qt.AlignVCenter
-            }
-
-            PlasmaComponents.Button {
-                // icon.name: "media-volume-up"
-                text: i18n("+")
-                enabled: targetDevice.length > 0
-                onClicked: {
-                    currentVolume = Math.min(100, currentVolume + volumeStepBig); // sofort im UI
-                    queueVolumeChange(); // nach kurzer Zeit >= setVolume()
-                }
-            }
-
-        }
-
-        Platform.FileDialog {
-            id: fileDialog
-
-            title: i18n("Open file")
-            nameFilters: ["Media (*.mp4 *.mkv *.webm *.mp3)", "Alle Dateien (*)"]
-            onAccepted: {
-                updateMediaInput(file);
-            }
-        }
-
-        Connections {
-            // erstes gefundenes nehmen
-            // z.B. eine Fehlermeldung sichtbar schalten
-
-            function onDefaultDeviceChanged(name) {
-                const deviceIndex = indexOfDevice(name);
-                if (deviceIndex >= 0 && deviceSelector.currentIndex !== deviceIndex)
-                    deviceSelector.currentIndex = deviceIndex;
-            }
-
-            function onDevicesChanged() {
-                if (deviceSelector.currentIndex >= 0)
-                    return ;
-
-                const deviceIndex = indexOfDevice(kcast.defaultDevice);
-                if (deviceIndex >= 0)
-                    deviceSelector.currentIndex = deviceIndex;
-                else if (deviceOptions().length > 0)
-                    deviceSelector.currentIndex = 0;
-            }
-
-            function onDeviceFound(name) {
-                if (devices.indexOf(name) === -1)
-                    devices = devices.concat([name]);
-
-                // trigger Bindings
-                if (!kcast.defaultDevice || kcast.defaultDevice.length === 0)
-                    kcast.setDefaultDevice(name);
-
-            }
-
-            function onDevicesScanned(list) {
-                devices = list ? list : [];
-                isScanning = false;
-                // Optional: InlineMessage zeigen, falls leer
-                if (devices.length === 0) {
-                }
-            }
-
-            target: kcast
         }
 
     }

--- a/package/metadata.json
+++ b/package/metadata.json
@@ -7,7 +7,7 @@
       "Plasma/Applet"
     ],
     "Name": "KCast",
-    "Icon": "beamerframe",
+    "Icon": "de.agundur.kcast",
     "Description": "chromecast videos to a device",
     "Authors": [
       {

--- a/package/plugin/kcastinterface.cpp
+++ b/package/plugin/kcastinterface.cpp
@@ -14,6 +14,7 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QProcess>
+#include <QRegularExpression>
 #include <QStandardPaths>
 #include <QString>
 #include <QStringList>
@@ -22,15 +23,22 @@
 #include <QTimer>
 #include <QUrl>
 #include <algorithm>
+#include <memory>
 
 using namespace Qt::StringLiterals;
+
+QList<KCastBridge *> KCastBridge::s_instances;
+KCastBridge *KCastBridge::s_pollOwner = nullptr;
+QString KCastBridge::s_sharedDefaultDevice;
+QStringList KCastBridge::s_sharedDevices;
+QString KCastBridge::s_sharedMediaUrl;
+QHash<QString, KCastBridge::SessionState> KCastBridge::s_sharedSessions;
 
 void customMessageHandler(QtMsgType type, const QMessageLogContext &, const QString &msg)
 {
     static QFile logFile(QDir::homePath() + QStringLiteral("/.local/share/kcast.log"));
-    if (!logFile.isOpen()) {
-        logFile.open(QIODevice::WriteOnly | QIODevice::Append | QIODevice::Text);
-    }
+    if (!logFile.isOpen() && !logFile.open(QIODevice::WriteOnly | QIODevice::Append | QIODevice::Text))
+        return;
 
     QTextStream out(&logFile);
 
@@ -60,6 +68,9 @@ void customMessageHandler(QtMsgType type, const QMessageLogContext &, const QStr
 KCastBridge::KCastBridge(QObject *parent)
     : QObject(parent)
 {
+    s_instances.append(this);
+    ensurePollOwner();
+
     // qInstallMessageHandler(customMessageHandler);
 
     // kurze Bündel-Zeit: UI darf „ausrauschen“, dann 1x senden
@@ -70,46 +81,397 @@ KCastBridge::KCastBridge(QObject *parent)
     // Mindestabstand zwischen zwei catt-Spawns (Python-Interpreter-Overhead!)
     m_rateLimitTimer.setSingleShot(true);
     m_rateLimitTimer.setInterval(100);
+
+    m_statusPollTimer.setInterval(1000);
+    connect(&m_statusPollTimer, &QTimer::timeout, this, &KCastBridge::refreshPlaybackStatus);
+
+    m_statusPollBoostTimer.setSingleShot(true);
+    m_statusPollBoostTimer.setInterval(1600);
+    connect(&m_statusPollBoostTimer, &QTimer::timeout, this, [this]() {
+        m_statusPollTimer.setInterval(1000);
+        if (m_statusPollTimer.isActive())
+            m_statusPollTimer.start();
+    });
+
+    adoptSharedState();
+
+    if (s_pollOwner == this && hasSharedActiveSessions())
+        startPlaybackStatusPolling(false);
+}
+
+KCastBridge::~KCastBridge()
+{
+    m_statusPollBoostTimer.stop();
+    m_statusPollTimer.stop();
+    s_instances.removeAll(this);
+
+    if (s_pollOwner == this) {
+        s_pollOwner = nullptr;
+        ensurePollOwner();
+        if (s_pollOwner && hasSharedActiveSessions())
+            s_pollOwner->startPlaybackStatusPolling(false);
+    }
+}
+
+bool KCastBridge::applyDefaultDeviceLocal(const QString &name, bool emitSignal)
+{
+    if (m_defaultDevice == name)
+        return false;
+
+    m_defaultDevice = name;
+    if (emitSignal)
+        Q_EMIT defaultDeviceChanged(m_defaultDevice);
+    return true;
+}
+
+bool KCastBridge::applyDevicesLocal(const QStringList &devices, bool emitSignal)
+{
+    if (m_devices == devices)
+        return false;
+
+    m_devices = devices;
+    if (emitSignal)
+        Q_EMIT devicesChanged(m_devices);
+    return true;
+}
+
+bool KCastBridge::applyMediaUrlLocal(const QString &url, bool emitSignal)
+{
+    if (m_mediaUrl == url)
+        return false;
+
+    m_mediaUrl = url;
+    if (emitSignal)
+        Q_EMIT mediaUrlChanged();
+    return true;
+}
+
+bool KCastBridge::applyPlayingLocal(bool on, bool emitSignal)
+{
+    if (m_playing == on)
+        return false;
+
+    m_playing = on;
+    if (emitSignal)
+        Q_EMIT playingChanged();
+    return true;
+}
+
+bool KCastBridge::applySessionActiveLocal(bool on, bool emitSignal)
+{
+    if (m_sessionActive == on)
+        return false;
+
+    m_sessionActive = on;
+    if (emitSignal)
+        Q_EMIT sessionActiveChanged();
+    return true;
+}
+
+bool KCastBridge::applyMediaPositionLocal(int seconds, bool emitSignal)
+{
+    seconds = std::max(seconds, 0);
+    if (m_mediaDuration > 0)
+        seconds = std::min(seconds, m_mediaDuration);
+    if (m_mediaPosition == seconds)
+        return false;
+
+    m_mediaPosition = seconds;
+    if (emitSignal)
+        Q_EMIT mediaPositionChanged();
+    return true;
+}
+
+bool KCastBridge::applyMediaDurationLocal(int seconds, bool emitSignal)
+{
+    seconds = std::max(seconds, 0);
+    if (m_mediaDuration == seconds)
+        return false;
+
+    m_mediaDuration = seconds;
+    const bool positionChanged = m_mediaDuration > 0 && m_mediaPosition > m_mediaDuration;
+    if (positionChanged)
+        m_mediaPosition = m_mediaDuration;
+
+    if (emitSignal) {
+        Q_EMIT mediaDurationChanged();
+        if (positionChanged)
+            Q_EMIT mediaPositionChanged();
+    }
+    return true;
+}
+
+bool KCastBridge::applyMediaSeekableLocal(bool on, bool emitSignal)
+{
+    if (m_mediaSeekable == on)
+        return false;
+
+    m_mediaSeekable = on;
+    if (emitSignal)
+        Q_EMIT mediaSeekableChanged();
+    return true;
+}
+
+void KCastBridge::adoptSharedState()
+{
+    applyDevicesLocal(s_sharedDevices, false);
+    applyDefaultDeviceLocal(s_sharedDefaultDevice, false);
+    applyMediaUrlLocal(s_sharedMediaUrl, false);
+    syncLegacyPlaybackState();
+}
+
+void KCastBridge::syncLegacyPlaybackState()
+{
+    const SessionState *session = preferredSession();
+    if (!session) {
+        applyPlayingLocal(false, true);
+        applySessionActiveLocal(false, true);
+        applyMediaPositionLocal(0, true);
+        applyMediaDurationLocal(0, true);
+        applyMediaSeekableLocal(false, true);
+        return;
+    }
+
+    applyPlayingLocal(session->playing, true);
+    applySessionActiveLocal(session->sessionActive, true);
+    applyMediaDurationLocal(session->mediaDuration, true);
+    applyMediaPositionLocal(session->mediaPosition, true);
+    applyMediaSeekableLocal(session->mediaSeekable, true);
+}
+
+const KCastBridge::SessionState *KCastBridge::preferredSession() const
+{
+    if (!m_defaultDevice.isEmpty()) {
+        if (const SessionState *session = sharedSessionConst(m_defaultDevice))
+            return session;
+    }
+
+    const QString fallbackDevice = firstSharedSessionDevice();
+    if (!fallbackDevice.isEmpty())
+        return sharedSessionConst(fallbackDevice);
+
+    return nullptr;
+}
+
+QVariantMap KCastBridge::sessionToVariantMap(const SessionState &session)
+{
+    QVariantMap map;
+    map.insert(u"device"_s, session.device);
+    map.insert(u"mediaUrl"_s, session.mediaUrl);
+    map.insert(u"playing"_s, session.playing);
+    map.insert(u"sessionActive"_s, session.sessionActive);
+    map.insert(u"mediaPosition"_s, session.mediaPosition);
+    map.insert(u"mediaDuration"_s, session.mediaDuration);
+    map.insert(u"mediaSeekable"_s, session.mediaSeekable);
+    map.insert(u"volume"_s, session.volume);
+    map.insert(u"muted"_s, session.muted);
+    return map;
+}
+
+KCastBridge::SessionState *KCastBridge::sharedSession(const QString &device)
+{
+    auto it = s_sharedSessions.find(device);
+    if (it == s_sharedSessions.end())
+        return nullptr;
+    return &it.value();
+}
+
+const KCastBridge::SessionState *KCastBridge::sharedSessionConst(const QString &device)
+{
+    auto it = s_sharedSessions.constFind(device);
+    if (it == s_sharedSessions.cend())
+        return nullptr;
+    return &it.value();
+}
+
+QStringList KCastBridge::activeSessionDevices()
+{
+    QStringList devices;
+    for (auto it = s_sharedSessions.cbegin(); it != s_sharedSessions.cend(); ++it) {
+        if (it.value().sessionActive)
+            devices.append(it.key());
+    }
+    return devices;
+}
+
+QString KCastBridge::firstSharedSessionDevice()
+{
+    if (s_sharedSessions.isEmpty())
+        return {};
+
+    QStringList keys = s_sharedSessions.keys();
+    std::sort(keys.begin(), keys.end());
+    return keys.constFirst();
+}
+
+bool KCastBridge::hasSharedActiveSessions()
+{
+    for (auto it = s_sharedSessions.cbegin(); it != s_sharedSessions.cend(); ++it) {
+        if (it.value().sessionActive)
+            return true;
+    }
+    return false;
+}
+
+void KCastBridge::removeSharedSession(const QString &device)
+{
+    s_sharedSessions.remove(device);
+}
+
+void KCastBridge::broadcastSessionsChanged()
+{
+    for (KCastBridge *instance : s_instances) {
+        if (!instance)
+            continue;
+        instance->syncLegacyPlaybackState();
+        Q_EMIT instance->sessionsChanged();
+    }
+}
+
+void KCastBridge::broadcastDefaultDeviceChanged()
+{
+    for (KCastBridge *instance : s_instances) {
+        if (!instance)
+            continue;
+        instance->applyDefaultDeviceLocal(s_sharedDefaultDevice, true);
+        instance->syncLegacyPlaybackState();
+    }
+}
+
+void KCastBridge::broadcastDevicesChanged()
+{
+    for (KCastBridge *instance : s_instances) {
+        if (instance)
+            instance->applyDevicesLocal(s_sharedDevices, true);
+    }
+}
+
+void KCastBridge::ensurePollOwner()
+{
+    if (s_pollOwner && s_instances.contains(s_pollOwner))
+        return;
+
+    s_pollOwner = s_instances.isEmpty() ? nullptr : s_instances.constFirst();
+}
+
+QString KCastBridge::cattExecutable() const
+{
+    const QString resolved = QStandardPaths::findExecutable(u"catt"_s);
+    if (!resolved.isEmpty())
+        return resolved;
+
+    return u"catt"_s;
 }
 
 void KCastBridge::playMedia(const QString &device, const QString &url)
 {
-    bool ok = QProcess::startDetached(QString::fromUtf8("catt"), QStringList() << QString::fromUtf8("-d") << device << QString::fromUtf8("cast") << url);
+    const bool ok = QProcess::startDetached(cattExecutable(), QStringList() << QString::fromUtf8("-d") << device << QString::fromUtf8("cast") << url);
     if (!ok) {
         qWarning() << QString::fromUtf8("Failed to start catt cast");
+        return;
     }
-    setPlaying(true);
+
+    SessionState &session = s_sharedSessions[device];
+    session.device = device;
+    session.mediaUrl = url;
+    session.playing = true;
+    session.sessionActive = true;
+    session.mediaPosition = 0;
+    session.mediaDuration = 0;
+    session.mediaSeekable = false;
+    session.statusInFlight = false;
+    ++session.statusGeneration;
+
+    setMediaUrl(url);
+    broadcastSessionsChanged();
+    boostPlaybackStatusPolling();
+    startPlaybackStatusPolling(false);
 }
 
 void KCastBridge::pauseMedia(const QString &device)
 {
-    bool ok = QProcess::startDetached(u"catt"_s, QStringList{u"-d"_s, device, u"pause"_s});
-    if (!ok)
+    const bool ok = QProcess::startDetached(cattExecutable(), QStringList{u"-d"_s, device, u"pause"_s});
+    if (!ok) {
         qWarning() << u"[KCast] Failed to start catt pause"_s;
-    setPlaying(false);
+        return;
+    }
+
+    SessionState &session = s_sharedSessions[device];
+    session.device = device;
+    session.playing = false;
+    session.sessionActive = true;
+    session.statusInFlight = false;
+    ++session.statusGeneration;
+    broadcastSessionsChanged();
+    startPlaybackStatusPolling(false);
 }
 
 void KCastBridge::resumeMedia(const QString &device)
 {
     using namespace Qt::StringLiterals;
 
-    const bool ok = QProcess::startDetached(u"catt"_s, QStringList{u"-d"_s, device, u"play"_s});
+    const bool ok = QProcess::startDetached(cattExecutable(), QStringList{u"-d"_s, device, u"play"_s});
 
     if (!ok) {
         qWarning() << u"[KCast] Failed to start catt play (resume)"_s;
         return;
     }
 
-    setPlaying(true);
+    SessionState &session = s_sharedSessions[device];
+    session.device = device;
+    session.playing = true;
+    session.sessionActive = true;
+    session.statusInFlight = false;
+    ++session.statusGeneration;
+    broadcastSessionsChanged();
+    startPlaybackStatusPolling(false);
 }
 
 void KCastBridge::stopMedia(const QString &device)
 {
-    bool ok = QProcess::startDetached(QString::fromUtf8("catt"), QStringList() << QString::fromUtf8("-d") << device << QString::fromUtf8("stop"));
+    const bool ok = QProcess::startDetached(cattExecutable(), QStringList() << QString::fromUtf8("-d") << device << QString::fromUtf8("stop"));
     if (!ok) {
         qWarning() << QString::fromUtf8("Failed to start catt stop");
+        return;
     }
-    setPlaying(false);
+
+    stopPlaybackStatusPolling(device, true);
+}
+
+bool KCastBridge::seekTo(int seconds)
+{
+    const QString device = pickDefaultDevice();
+    return seekOnDevice(device, seconds);
+}
+
+bool KCastBridge::seekOnDevice(const QString &device, int seconds)
+{
+    if (device.isEmpty()) {
+        qWarning() << u"[KCast] seekTo: default device not set."_s;
+        return false;
+    }
+
+    seconds = std::max(seconds, 0);
+    const bool ok = QProcess::startDetached(cattExecutable(), QStringList{u"-d"_s, device, u"seek"_s, QString::number(seconds)});
+    if (!ok) {
+        qWarning() << u"[KCast] Failed to start catt seek"_s;
+        return false;
+    }
+
+    SessionState &session = s_sharedSessions[device];
+    session.device = device;
+    session.sessionActive = true;
+    session.mediaPosition = seconds;
+    if (session.mediaDuration > 0)
+        session.mediaPosition = std::min(session.mediaPosition, session.mediaDuration);
+    session.statusInFlight = false;
+    ++session.statusGeneration;
+    broadcastSessionsChanged();
+    boostPlaybackStatusPolling();
+    startPlaybackStatusPolling(false);
+    QTimer::singleShot(160, this, &KCastBridge::refreshPlaybackStatus);
+    QTimer::singleShot(420, this, &KCastBridge::refreshPlaybackStatus);
+    return true;
 }
 
 bool KCastBridge::isCattInstalled() const
@@ -129,7 +491,7 @@ bool KCastBridge::isCattInstalled() const
 void KCastBridge::scanDevicesAsync()
 {
     auto *p = new QProcess(this);
-    p->setProgram(QStringLiteral("catt"));
+    p->setProgram(cattExecutable());
     p->setArguments({QStringLiteral("scan")});
     p->setProcessChannelMode(QProcess::MergedChannels);
 
@@ -164,13 +526,13 @@ void KCastBridge::scanDevicesAsync()
                     Q_EMIT deviceFound(name); // Live-Update fürs UI
 
                     // Properties live synchron halten
-                    if (!m_devices.contains(name)) {
-                        m_devices.append(name);
-                        Q_EMIT devicesChanged(m_devices);
+                    if (!s_sharedDevices.contains(name)) {
+                        s_sharedDevices.append(name);
+                        broadcastDevicesChanged();
                     }
-                    if (m_defaultDevice.isEmpty()) {
-                        m_defaultDevice = name;
-                        Q_EMIT defaultDeviceChanged(m_defaultDevice);
+                    if (s_sharedDefaultDevice.isEmpty()) {
+                        s_sharedDefaultDevice = name;
+                        broadcastDefaultDeviceChanged();
                     }
                 }
             }
@@ -187,21 +549,21 @@ void KCastBridge::scanDevicesAsync()
                 if (!name.isEmpty() && !acc->contains(name)) {
                     acc->append(name);
                     Q_EMIT deviceFound(name);
-                    if (!m_devices.contains(name)) {
-                        m_devices.append(name);
-                        Q_EMIT devicesChanged(m_devices);
+                    if (!s_sharedDevices.contains(name)) {
+                        s_sharedDevices.append(name);
+                        broadcastDevicesChanged();
                     }
-                    if (m_defaultDevice.isEmpty()) {
-                        m_defaultDevice = name;
-                        Q_EMIT defaultDeviceChanged(m_defaultDevice);
+                    if (s_sharedDefaultDevice.isEmpty()) {
+                        s_sharedDefaultDevice = name;
+                        broadcastDefaultDeviceChanged();
                     }
                 }
             }
         }
 
-        if (m_devices != *acc) {
-            m_devices = *acc;
-            Q_EMIT devicesChanged(m_devices);
+        if (s_sharedDevices != *acc) {
+            s_sharedDevices = *acc;
+            broadcastDevicesChanged();
         }
         Q_EMIT devicesScanned(*acc);
 
@@ -223,6 +585,23 @@ static QString toLocalMediaPath(const QString &in)
     return in;
 }
 
+static QString decodePercentEncodedLocalPath(const QString &in)
+{
+    if (!in.contains(u'%'))
+        return in;
+
+    const QString decoded = QUrl::fromPercentEncoding(in.toUtf8());
+    if (decoded == in)
+        return in;
+
+    const QFileInfo originalInfo(in);
+    const QFileInfo decodedInfo(decoded);
+    if (!originalInfo.exists() && decodedInfo.exists())
+        return decodedInfo.absoluteFilePath();
+
+    return in;
+}
+
 void KCastBridge::probeReceiver(const QString &assetUrl)
 {
     const QString dev = pickDefaultDevice();
@@ -241,18 +620,18 @@ void KCastBridge::probeReceiver(const QString &assetUrl)
 
     const QString local = toLocalMediaPath(asset);
 
-    QProcess::startDetached(u"catt"_s, {u"-d"_s, dev, u"stop"_s});
-    QProcess::startDetached(u"catt"_s, {u"-d"_s, dev, u"quit"_s});
+    QProcess::startDetached(cattExecutable(), {u"-d"_s, dev, u"stop"_s});
+    QProcess::startDetached(cattExecutable(), {u"-d"_s, dev, u"quit"_s});
 
     QTimer::singleShot(350, this, [dev, local]() {
         auto *p = new QProcess();
-        p->setProgram(u"catt"_s);
+        p->setProgram(QStandardPaths::findExecutable(u"catt"_s));
         p->setArguments({u"-d"_s, dev, u"cast"_s, local});
         p->setProcessChannelMode(QProcess::MergedChannels);
         QObject::connect(p, &QProcess::finished, p, [dev, p] {
             const QString out = QString::fromUtf8(p->readAll());
             p->deleteLater();
-            QProcess::startDetached(u"catt"_s, {u"-d"_s, dev, u"quit"_s});
+            QProcess::startDetached(QStandardPaths::findExecutable(u"catt"_s), {u"-d"_s, dev, u"quit"_s});
             // Optional: out auf CC1AD845 prüfen und ein Signal emittieren
         });
         p->start();
@@ -289,10 +668,40 @@ bool KCastBridge::registerDBus()
 
 void KCastBridge::setMediaUrl(const QString &url)
 {
-    if (m_mediaUrl == url)
-        return;
-    m_mediaUrl = url;
-    Q_EMIT mediaUrlChanged();
+    s_sharedMediaUrl = url;
+    for (KCastBridge *instance : s_instances) {
+        if (instance)
+            instance->applyMediaUrlLocal(url, true);
+    }
+}
+
+QVariantList KCastBridge::sessions() const
+{
+    QVariantList list;
+    QStringList keys = s_sharedSessions.keys();
+    std::sort(keys.begin(), keys.end());
+    for (const QString &key : keys)
+        list.push_back(sessionToVariantMap(s_sharedSessions.value(key)));
+    return list;
+}
+
+QVariantMap KCastBridge::sessionForDevice(const QString &device) const
+{
+    if (const SessionState *session = sharedSessionConst(device))
+        return sessionToVariantMap(*session);
+    return {};
+}
+
+bool KCastBridge::hasSessionForDevice(const QString &device) const
+{
+    return sharedSessionConst(device) != nullptr;
+}
+
+QString KCastBridge::firstActiveSessionDevice() const
+{
+    for (const QString &device : activeSessionDevices())
+        return device;
+    return firstSharedSessionDevice();
 }
 
 QString KCastBridge::pickDefaultDevice() const
@@ -300,30 +709,275 @@ QString KCastBridge::pickDefaultDevice() const
     return m_defaultDevice;
 }
 
+QString KCastBridge::normalizeMediaInput(const QString &input) const
+{
+    return normalizeUrlForCasting(input);
+}
+
 QString KCastBridge::normalizeUrlForCasting(const QString &in) const
 {
-    QUrl u = QUrl::fromUserInput(in);
+    const QString trimmed = in.trimmed();
+    if (trimmed.isEmpty())
+        return {};
+
+    const bool hasScheme = trimmed.contains(u"://"_s);
+    const QString candidate = hasScheme ? trimmed : decodePercentEncodedLocalPath(trimmed);
+    QUrl u = QUrl::fromUserInput(candidate);
     if (u.isLocalFile()) {
         return u.toLocalFile(); // kein file:// → vermeidet yt-dlp-Block
     }
-    if (u.isRelative() && QFileInfo(in).exists()) {
-        return QFileInfo(in).absoluteFilePath();
+    if (u.isRelative() && QFileInfo(candidate).exists()) {
+        return QFileInfo(candidate).absoluteFilePath();
     }
     return u.toString(); // http/https o.ä.
+}
+
+std::optional<int> KCastBridge::parseClockTime(const QString &value)
+{
+    const QStringList parts = value.split(u':');
+    if (parts.size() != 3)
+        return std::nullopt;
+
+    bool okHours = false;
+    bool okMinutes = false;
+    bool okSeconds = false;
+    const int hours = parts.at(0).toInt(&okHours);
+    const int minutes = parts.at(1).toInt(&okMinutes);
+    const int seconds = parts.at(2).toInt(&okSeconds);
+    if (!okHours || !okMinutes || !okSeconds)
+        return std::nullopt;
+
+    return (hours * 3600) + (minutes * 60) + seconds;
+}
+
+void KCastBridge::resetPlaybackMetrics()
+{
+    setMediaPosition(0);
+    setMediaDuration(0);
+    setMediaSeekable(false);
+}
+
+void KCastBridge::boostPlaybackStatusPolling()
+{
+    ensurePollOwner();
+    if (s_pollOwner && s_pollOwner != this) {
+        s_pollOwner->boostPlaybackStatusPolling();
+        return;
+    }
+
+    m_statusPollTimer.setInterval(250);
+    if (m_statusPollTimer.isActive())
+        m_statusPollTimer.start();
+    m_statusPollBoostTimer.start();
+}
+
+void KCastBridge::startPlaybackStatusPolling(bool immediate)
+{
+    ensurePollOwner();
+    if (s_pollOwner && s_pollOwner != this) {
+        s_pollOwner->startPlaybackStatusPolling(immediate);
+        return;
+    }
+
+    if (!hasSharedActiveSessions())
+        return;
+
+    if (!m_statusPollTimer.isActive())
+        m_statusPollTimer.start();
+
+    if (immediate)
+        refreshPlaybackStatus();
+}
+
+void KCastBridge::stopPlaybackStatusPolling(const QString &device, bool removeSession)
+{
+    if (SessionState *session = sharedSession(device)) {
+        session->statusInFlight = false;
+        ++session->statusGeneration;
+
+        if (removeSession) {
+            removeSharedSession(device);
+        } else {
+            session->playing = false;
+            session->sessionActive = false;
+            session->mediaPosition = 0;
+            session->mediaDuration = 0;
+            session->mediaSeekable = false;
+        }
+    }
+
+    if (s_pollOwner) {
+        if (!hasSharedActiveSessions()) {
+            s_pollOwner->m_statusPollTimer.stop();
+            s_pollOwner->m_statusPollBoostTimer.stop();
+            s_pollOwner->m_statusPollTimer.setInterval(1000);
+        } else if (s_pollOwner != this) {
+            s_pollOwner->startPlaybackStatusPolling(false);
+        }
+    }
+
+    broadcastSessionsChanged();
+}
+
+void KCastBridge::refreshPlaybackStatus()
+{
+    ensurePollOwner();
+    if (s_pollOwner && s_pollOwner != this) {
+        s_pollOwner->refreshPlaybackStatus();
+        return;
+    }
+
+    for (const QString &device : activeSessionDevices()) {
+        SessionState *session = sharedSession(device);
+        if (!session || session->statusInFlight)
+            continue;
+
+        auto *p = new QProcess(this);
+        const auto handled = std::make_shared<bool>(false);
+        const quint64 generation = session->statusGeneration;
+
+        session->statusInFlight = true;
+        p->setProgram(cattExecutable());
+        p->setArguments({u"-d"_s, device, u"status"_s});
+        p->setProcessChannelMode(QProcess::MergedChannels);
+
+        const auto finalize = [this, p, handled, device, generation](const QString &output, bool shouldParse) {
+            if (*handled)
+                return;
+
+            *handled = true;
+
+            if (SessionState *session = sharedSession(device)) {
+                if (session->statusGeneration == generation) {
+                    session->statusInFlight = false;
+                    if (shouldParse)
+                        applyPlaybackStatus(device, output);
+                }
+            }
+
+            p->deleteLater();
+        };
+
+        connect(p, &QProcess::finished, this, [finalize, p](int, QProcess::ExitStatus) {
+            finalize(QString::fromUtf8(p->readAll()), true);
+        });
+        connect(p, &QProcess::errorOccurred, this, [finalize, p](QProcess::ProcessError) {
+            finalize(QString::fromUtf8(p->readAll()), false);
+        });
+        p->start();
+    }
+}
+
+void KCastBridge::applyPlaybackStatus(const QString &device, const QString &output)
+{
+    const QString trimmedOutput = output.trimmed();
+    if (trimmedOutput.isEmpty())
+        return;
+
+    static const QRegularExpression timePattern(QStringLiteral(R"(^Time:\s*([0-9]{2}:[0-9]{2}:[0-9]{2})(?:\s*/\s*([0-9]{2}:[0-9]{2}:[0-9]{2})\s*\(([\d.]+)%\))?\s*$)"));
+    static const QRegularExpression statePattern(QStringLiteral(R"(^State:\s*(\S+)\s*$)"));
+
+    std::optional<int> current;
+    std::optional<int> duration;
+    QString state;
+
+    const QStringList lines = trimmedOutput.split(u'\n', Qt::SkipEmptyParts);
+    for (const QString &rawLine : lines) {
+        const QString line = rawLine.trimmed();
+
+        const QRegularExpressionMatch timeMatch = timePattern.match(line);
+        if (timeMatch.hasMatch()) {
+            current = parseClockTime(timeMatch.captured(1));
+            if (!timeMatch.captured(2).isEmpty())
+                duration = parseClockTime(timeMatch.captured(2));
+            continue;
+        }
+
+        const QRegularExpressionMatch stateMatch = statePattern.match(line);
+        if (stateMatch.hasMatch()) {
+            state = stateMatch.captured(1).trimmed().toUpper();
+            continue;
+        }
+    }
+
+    SessionState *session = sharedSession(device);
+    if (!session)
+        return;
+
+    if (current.has_value())
+        session->mediaPosition = *current;
+
+    if (duration.has_value()) {
+        session->mediaDuration = *duration;
+        session->mediaSeekable = *duration > 0;
+    } else if (session->mediaDuration <= 0) {
+        // Some catt status responses omit total duration mid-playback.
+        // Keep the last known duration so the seek slider does not collapse to zero.
+        session->mediaSeekable = false;
+    }
+
+    if (state == u"PLAYING"_s || state == u"BUFFERING"_s) {
+        session->sessionActive = true;
+        session->playing = true;
+        broadcastSessionsChanged();
+        return;
+    }
+
+    if (state == u"PAUSED"_s) {
+        session->sessionActive = true;
+        session->playing = false;
+        broadcastSessionsChanged();
+        return;
+    }
+
+    if (state == u"IDLE"_s || state == u"UNKNOWN"_s) {
+        stopPlaybackStatusPolling(device, true);
+        return;
+    }
+
+    if (current.has_value())
+        session->sessionActive = true;
+
+    broadcastSessionsChanged();
+}
+
+void KCastBridge::setSessionActive(bool on)
+{
+    applySessionActiveLocal(on, true);
+}
+
+void KCastBridge::setMediaPosition(int seconds)
+{
+    applyMediaPositionLocal(seconds, true);
+}
+
+void KCastBridge::setMediaDuration(int seconds)
+{
+    applyMediaDurationLocal(seconds, true);
+}
+
+void KCastBridge::setMediaSeekable(bool on)
+{
+    applyMediaSeekableLocal(on, true);
+}
+
+void KCastBridge::setPlaying(bool on)
+{
+    applyPlayingLocal(on, true);
 }
 
 // ---- QML-Setter ----
 void KCastBridge::setDefaultDevice(const QString &name)
 {
-    if (m_defaultDevice == name)
+    if (s_sharedDefaultDevice == name)
         return;
-    m_defaultDevice = name;
-    // <<< NEU: Default immer in Liste aufnehmen >>>
-    if (!m_devices.contains(name)) {
-        m_devices.append(name);
-        Q_EMIT devicesChanged(m_devices);
+
+    s_sharedDefaultDevice = name;
+    if (!s_sharedDevices.contains(name)) {
+        s_sharedDevices.append(name);
+        broadcastDevicesChanged();
     }
-    Q_EMIT defaultDeviceChanged(m_defaultDevice);
+    broadcastDefaultDeviceChanged();
 }
 
 // ---- D-Bus Slots ----
@@ -380,34 +1034,74 @@ void KCastBridge::scheduleDbusRetry()
 
 bool KCastBridge::setVolume(int level)
 {
-    level = clampVolume(level);
-    requestVolumeAbsolute(level);
-    Q_EMIT volumeCommandSent(u"set"_s, level); // UI darf sofort hochzählen
-    return true;
+    return setVolumeForDevice(pickDefaultDevice(), level);
 }
 
 bool KCastBridge::volumeUp(int delta)
 {
     if (delta <= 0)
         delta = 5;
-    const int base = m_desiredVolume.has_value() ? *m_desiredVolume : (m_lastSentVolume >= 0 ? m_lastSentVolume : 50);
-    return setVolume(base + delta);
+    const QString device = pickDefaultDevice();
+    const SessionState *session = sharedSessionConst(device);
+    const int base = session ? session->volume : 50;
+    return setVolumeForDevice(device, base + delta);
 }
 
 bool KCastBridge::volumeDown(int delta)
 {
     if (delta <= 0)
         delta = 5;
-    const int base = m_desiredVolume.has_value() ? *m_desiredVolume : (m_lastSentVolume >= 0 ? m_lastSentVolume : 50);
-    return setVolume(base - delta);
+    const QString device = pickDefaultDevice();
+    const SessionState *session = sharedSessionConst(device);
+    const int base = session ? session->volume : 50;
+    return setVolumeForDevice(device, base - delta);
 }
 
 bool KCastBridge::setMuted(bool on)
 {
-    const bool ok = spawnCattMute(on);
+    return setMutedForDevice(pickDefaultDevice(), on);
+}
+
+bool KCastBridge::setVolumeForDevice(const QString &device, int level)
+{
+    if (device.isEmpty()) {
+        qWarning() << u"[KCast] setVolumeForDevice: default device not set."_s;
+        return false;
+    }
+
+    level = clampVolume(level);
+    const QStringList args{u"-d"_s, device, u"volume"_s, QString::number(level)};
+    const bool ok = QProcess::startDetached(cattExecutable(), args);
+    if (!ok) {
+        qWarning() << u"[KCast] Failed to start catt volume."_s;
+        return false;
+    }
+
+    if (SessionState *session = sharedSession(device)) {
+        session->volume = level;
+        broadcastSessionsChanged();
+    }
+    Q_EMIT volumeCommandSent(u"set"_s, level);
+    return true;
+}
+
+bool KCastBridge::setMutedForDevice(const QString &device, bool on)
+{
+    if (device.isEmpty()) {
+        qWarning() << u"[KCast] setMutedForDevice: no Chromecast device available."_s;
+        return false;
+    }
+
+    const QStringList args{u"-d"_s, device, u"volumemute"_s, on ? u"true"_s : u"false"_s};
+    const bool ok = QProcess::startDetached(cattExecutable(), args);
     if (!ok) {
         qWarning() << u"[KCast] Failed to start catt volumemute."_s;
         return false;
+    }
+
+    if (SessionState *session = sharedSession(device)) {
+        session->muted = on;
+        broadcastSessionsChanged();
     }
     Q_EMIT muteCommandSent(on);
     return true;
@@ -467,7 +1161,7 @@ bool KCastBridge::spawnCattSetVolume(int level)
         return false; // NICHT scannen!
     }
     const QStringList args{u"-d"_s, device, u"volume"_s, QString::number(level)};
-    return QProcess::startDetached(u"catt"_s, args);
+    return QProcess::startDetached(cattExecutable(), args);
 }
 
 bool KCastBridge::spawnCattMute(bool on)
@@ -479,5 +1173,5 @@ bool KCastBridge::spawnCattMute(bool on)
     }
     // catt --help: volumemute  Enable or disable mute on supported devices.
     const QStringList args{u"-d"_s, device, u"volumemute"_s, on ? u"true"_s : u"false"_s};
-    return QProcess::startDetached(u"catt"_s, args);
+    return QProcess::startDetached(cattExecutable(), args);
 }

--- a/package/plugin/kcastinterface.h
+++ b/package/plugin/kcastinterface.h
@@ -2,6 +2,9 @@
 #define KCASTINTERFACE_H
 
 #include <QByteArray>
+#include <QHash>
+#include <QList>
+#include <algorithm>
 #include <QObject>
 #include <QProcess>
 #include <QQmlEngine>
@@ -9,6 +12,9 @@
 #include <QString>
 #include <QStringList>
 #include <QTimer>
+#include <QVariantList>
+#include <QVariantMap>
+#include <optional>
 
 class KCastBridge : public QObject
 {
@@ -18,6 +24,11 @@ class KCastBridge : public QObject
 
     Q_PROPERTY(QString mediaUrl READ mediaUrl WRITE setMediaUrl NOTIFY mediaUrlChanged FINAL)
     Q_PROPERTY(bool playing READ playing NOTIFY playingChanged FINAL)
+    Q_PROPERTY(bool sessionActive READ sessionActive NOTIFY sessionActiveChanged FINAL)
+    Q_PROPERTY(int mediaPosition READ mediaPosition NOTIFY mediaPositionChanged FINAL)
+    Q_PROPERTY(int mediaDuration READ mediaDuration NOTIFY mediaDurationChanged FINAL)
+    Q_PROPERTY(bool mediaSeekable READ mediaSeekable NOTIFY mediaSeekableChanged FINAL)
+    Q_PROPERTY(QVariantList sessions READ sessions NOTIFY sessionsChanged FINAL)
 
     Q_PROPERTY(QString defaultDevice READ defaultDevice NOTIFY defaultDeviceChanged)
     Q_PROPERTY(QStringList devices READ devices NOTIFY devicesChanged)
@@ -34,8 +45,12 @@ class KCastBridge : public QObject
 
 public:
     explicit KCastBridge(QObject *parent = nullptr);
+    ~KCastBridge() override;
 
     Q_INVOKABLE void scanDevicesAsync();
+    Q_INVOKABLE QString normalizeMediaInput(const QString &input) const;
+    Q_INVOKABLE bool seekTo(int seconds);
+    Q_INVOKABLE bool seekOnDevice(const QString &device, int seconds);
     Q_INVOKABLE void playMedia(const QString &device, const QString &url);
     Q_INVOKABLE void pauseMedia(const QString &device);
     Q_INVOKABLE void resumeMedia(const QString &device);
@@ -48,11 +63,33 @@ public:
     Q_INVOKABLE bool volumeUp(int delta = 5);
     Q_INVOKABLE bool volumeDown(int delta = 5);
     Q_INVOKABLE bool setMuted(bool on);
+    Q_INVOKABLE bool setVolumeForDevice(const QString &device, int level);
+    Q_INVOKABLE bool setMutedForDevice(const QString &device, bool on);
+    Q_INVOKABLE QVariantMap sessionForDevice(const QString &device) const;
+    Q_INVOKABLE bool hasSessionForDevice(const QString &device) const;
+    Q_INVOKABLE QString firstActiveSessionDevice() const;
 
     bool dbusReady() const
     {
         return m_dbusReady;
     }
+    bool sessionActive() const
+    {
+        return m_sessionActive;
+    }
+    int mediaPosition() const
+    {
+        return m_mediaPosition;
+    }
+    int mediaDuration() const
+    {
+        return m_mediaDuration;
+    }
+    bool mediaSeekable() const
+    {
+        return m_mediaSeekable;
+    }
+    QVariantList sessions() const;
     // Property
     QString mediaUrl() const
     {
@@ -76,27 +113,80 @@ Q_SIGNALS:
 
     void mediaUrlChanged();
     void playingChanged();
+    void sessionActiveChanged();
+    void mediaPositionChanged();
+    void mediaDurationChanged();
+    void mediaSeekableChanged();
+    void sessionsChanged();
     void dbusReadyChanged();
     void volumeCommandSent(QString command, int value);
     void muteCommandSent(bool muted);
 
 private:
+    struct SessionState {
+        QString device;
+        QString mediaUrl;
+        bool playing = false;
+        bool sessionActive = false;
+        int mediaPosition = 0;
+        int mediaDuration = 0;
+        bool mediaSeekable = false;
+        int volume = 50;
+        bool muted = false;
+        bool statusInFlight = false;
+        quint64 statusGeneration = 0;
+    };
+
+    bool applyDefaultDeviceLocal(const QString &name, bool emitSignal);
+    bool applyDevicesLocal(const QStringList &devices, bool emitSignal);
+    bool applyMediaUrlLocal(const QString &url, bool emitSignal);
+    bool applyPlayingLocal(bool on, bool emitSignal);
+    bool applySessionActiveLocal(bool on, bool emitSignal);
+    bool applyMediaPositionLocal(int seconds, bool emitSignal);
+    bool applyMediaDurationLocal(int seconds, bool emitSignal);
+    bool applyMediaSeekableLocal(bool on, bool emitSignal);
+    void adoptSharedState();
+    void syncLegacyPlaybackState();
+    const SessionState *preferredSession() const;
+    static QVariantMap sessionToVariantMap(const SessionState &session);
+    static SessionState *sharedSession(const QString &device);
+    static const SessionState *sharedSessionConst(const QString &device);
+    static QStringList activeSessionDevices();
+    static QString firstSharedSessionDevice();
+    static bool hasSharedActiveSessions();
+    static void removeSharedSession(const QString &device);
+    static void broadcastSessionsChanged();
+    static void broadcastDefaultDeviceChanged();
+    static void broadcastDevicesChanged();
+    static void ensurePollOwner();
     QString m_defaultDevice;
     QStringList m_devices;
 
     QString m_mediaUrl;
+    QString cattExecutable() const;
     QString pickDefaultDevice() const;
     QString normalizeUrlForCasting(const QString &in) const;
+    void startPlaybackStatusPolling(bool immediate = true);
+    void stopPlaybackStatusPolling(const QString &device, bool removeSession);
+    void refreshPlaybackStatus();
+    void applyPlaybackStatus(const QString &device, const QString &output);
+    static std::optional<int> parseClockTime(const QString &value);
+    void resetPlaybackMetrics();
+    void boostPlaybackStatusPolling();
+    void setSessionActive(bool on);
+    void setMediaPosition(int seconds);
+    void setMediaDuration(int seconds);
+    void setMediaSeekable(bool on);
     bool m_playing = false; // ← NEU
-    void setPlaying(bool on)
-    { // ← NEU
-        if (m_playing == on)
-            return;
-        m_playing = on;
-        Q_EMIT playingChanged();
-    }
+    void setPlaying(bool on); // ← NEU
 
     bool m_dbusReady = false;
+    bool m_sessionActive = false;
+    int m_mediaPosition = 0;
+    int m_mediaDuration = 0;
+    bool m_mediaSeekable = false;
+    bool m_statusPollInFlight = false;
+    quint64 m_statusPollGeneration = 0;
     void setDbusReady(bool on)
     {
         if (m_dbusReady == on)
@@ -123,6 +213,15 @@ private:
     int m_lastSentVolume = -1; // unbekannt am Start
     QTimer m_coalesceTimer; // bündelt schnelle Änderungen
     QTimer m_rateLimitTimer; // Mindestabstand zwischen Spawns
+    QTimer m_statusPollTimer; // leichter Poll für Seek-Status
+    QTimer m_statusPollBoostTimer; // kurz schneller nach Seek/Start
+
+    static QList<KCastBridge *> s_instances;
+    static KCastBridge *s_pollOwner;
+    static QString s_sharedDefaultDevice;
+    static QStringList s_sharedDevices;
+    static QString s_sharedMediaUrl;
+    static QHash<QString, SessionState> s_sharedSessions;
 };
 
 #endif // KCASTINTERFACE_H


### PR DESCRIPTION
This PR makes KCast much more usable for local media playback and day-to-day control.

Main improvements:
- adds proper seek support with a seek bar, current/total time display, and `-10s` / `+10s` skip buttons
- fixes local file casting for paths with brackets and encoded characters like `%5B` / `%5D`
- improves shared session handling across multiple widget instances
- adds session tabs for active cast sessions/devices
- smooths out seek/status UI behavior so the slider no longer snaps back or ping-pongs during refreshes
- improves general widget spacing and playback control polish
- fixes the missing plasmoid icon in the widget menu
- cleans up a small `QFile::open` build warning

File summary:
- `CMakeLists.txt`
  Added install rules for the KCast app icons so Plasma can resolve the plasmoid’s custom icon properly in the widget menu.

- `package/metadata.json`
  Changed the plasmoid icon from the old generic `beamerframe` icon name to `de.agundur.kcast`.

- `package/plugin/kcastinterface.h`
  Expanded the backend interface to support proper playback/session state, including per-device seek, volume, mute, and shared session tracking.

- `package/plugin/kcastinterface.cpp`
  Implemented the backend logic for local file path normalization, seek support, shared session polling/tracking, more reliable `catt` handling, and playback/UI stability fixes.

- `package/contents/ui/FullRepresentation.qml`
  Updated the UI to add the seek bar, time display, `-10s` / `+10s` seek buttons, session tabs, improved shared-session behavior, and several layout/stability fixes.

Tested manually:
- local file casting from drag-and-drop and file picker
- play / pause / resume / stop
- seek bar dragging
- `-10s` / `+10s` skip buttons
- volume / mute controls
- multiple widget instances
- plasmoid icon visibility after install