### PR TITLE
Allow manual device entry in cast target picker

### DIFF
--- a/package/contents/ui/configNetwork.qml
+++ b/package/contents/ui/configNetwork.qml
@@ -36,18 +36,30 @@ KCM.SimpleKCM {
             Kirigami.FormData.label: i18n("Default") + " :"
             Layout.fillWidth: true
             model: availableDevices
+            // Editierbar, damit ein Gerät auch manuell per Name oder IP
+            // eingetragen werden kann, wenn `catt scan` es nicht findet
+            // (z.B. bekannter catt-Discovery-Bug, siehe KCast#23) —
+            // `catt -d` akzeptiert beides.
+            editable: true
             Component.onCompleted: {
                 const idx = availableDevices.indexOf(cfg_DefaultDevice);
                 if (idx !== -1)
                     deviceCombo.currentIndex = idx;
                 else
                     deviceCombo.currentIndex = -1;
+                deviceCombo.editText = cfg_DefaultDevice;
             }
             // Wenn Auswahl geändert wird, speichere neuen Wert in kcfg_ → "Anwenden" wird aktiv
             onCurrentIndexChanged: {
                 if (currentIndex >= 0)
                     cfg_DefaultDevice = availableDevices[currentIndex];
 
+            }
+            // Manuell eingetippter Name/IP, der nicht (mehr) in der
+            // gescannten Liste steht — z.B. weil die Discovery leer blieb.
+            onEditTextChanged: {
+                if (currentIndex < 0)
+                    cfg_DefaultDevice = editText;
             }
         }
 


### PR DESCRIPTION
## Summary
- `catt scan` can fail to discover a device even though it's reachable and `catt -d <ip/name> cast ...` works fine directly (confirmed in #23: pychromecast/avahi find the device, `catt scan` doesn't).
- The device picker in `configNetwork.qml` only ever populated from `catt scan -j`, so anyone hit by that bug couldn't use the widget at all, despite casting itself working.
- Makes the device ComboBox editable so a name or IP can be typed in directly as a fallback when discovery comes up empty. `catt -d` (used everywhere in the casting logic) accepts both.

Closes #24

## Test plan
- [ ] Manually verify: scan populates the list as before when discovery works
- [ ] Manually verify: typing an IP/name not in the scanned list sets `cfg_DefaultDevice` and persists after Apply
- [ ] Manually verify: casting via the manually-entered device works end to end